### PR TITLE
Issue #47 Fix counting of filtered out dates

### DIFF
--- a/src/main/java/net/fortuna/ical4j/model/Recur.java
+++ b/src/main/java/net/fortuna/ical4j/model/Recur.java
@@ -594,7 +594,7 @@ public class Recur implements Serializable {
             }
         }
 
-        int invalidCandidateCount = 0;
+        HashSet<Date> invalidCandidates = new HashSet<Date>();
         int noCandidateIncrementCount = 0;
         Date candidate = null;
         while ((maxCount < 0) || (dates.size() < maxCount)) {
@@ -611,7 +611,7 @@ public class Recur implements Serializable {
                 break;
             }
             if (getCount() >= 1
-                    && (dates.size() + invalidCandidateCount) >= getCount()) {
+                    && (dates.size() + invalidCandidates.size()) >= getCount()) {
 
                 break;
             }
@@ -637,9 +637,9 @@ public class Recur implements Serializable {
                         // candidates exclusive of periodEnd..
                         if (candidate.before(periodStart)
                                 || !candidate.before(periodEnd)) {
-                            invalidCandidateCount++;
+                            invalidCandidates.add(candidate);
                         } else if (getCount() >= 1
-                                && (dates.size() + invalidCandidateCount) >= getCount()) {
+                                && (dates.size() + invalidCandidates.size()) >= getCount()) {
                             break;
                         } else if (!(getUntil() != null
                                 && candidate.after(getUntil()))) {

--- a/src/test/java/net/fortuna/ical4j/model/RecurTest.java
+++ b/src/test/java/net/fortuna/ical4j/model/RecurTest.java
@@ -833,6 +833,13 @@ public class RecurTest extends TestCase {
         recur = new Recur("FREQ=DAILY;COUNT=3;INTERVAL=1;BYDAY=MO,TU,WE,TH,FR");
         suite.addTest(new RecurTest(recur, new DateTime("20131215T000000Z"),
                 new DateTime("20131215T000000Z"), new DateTime("20180101T120000Z"), Value.DATE_TIME, 3));
+        
+        // rrule with bymonth and count. Should return correct number of occurrences near the end of its perioud.
+        recur = new Recur("FREQ=MONTHLY;COUNT=3;INTERVAL=1;BYMONTH=1,9,10,12;BYMONTHDAY=12");
+        suite.addTest(new RecurTest(recur, new DateTime("20150917T000000Z"),
+                new DateTime("20160101T000000Z"), new DateTime("20160201T000000Z"), Value.DATE, 1));
+        suite.addTest(new RecurTest(recur, new DateTime("20150917T000000Z"),
+                new DateTime("20160201T000000Z"), new DateTime("20160301T000000Z"), Value.DATE, 0));
       
         return suite;
     }


### PR DESCRIPTION
This fixes rules like

```
RRULE: FREQ=MONTHLY;WKST=FR;COUNT=3;INTERVAL=1;BYMONTH=1,9,10,12;BYMONTHDAY=12
```
