### PR TITLE
Removed svnkit transitional dependency from the build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,8 +9,10 @@ buildscript {
     dependencies {
 //        classpath 'org.ajoberstar:gradle-git:0.8.0'
 //        classpath 'me.trnl:github-release-gradle-plugin:0.1'
-        classpath 'au.com.ish.gradle:release:2.2.2',
-                'org.hidetake:gradle-ssh-plugin:1.1.3'
+        classpath ('au.com.ish.gradle:release:2.2.2') {
+            exclude module: 'svnkit'
+        }
+        classpath 'org.hidetake:gradle-ssh-plugin:1.1.3'
     }
 }
 


### PR DESCRIPTION
Accidentally noticed the problem today when their maven repository was down and I was not able to build iCal4j because of that. I do not think this project needs svn dependency anyway.