### PR TITLE
Add constructor to take Calendar value

### DIFF
--- a/src/main/java/net/fortuna/ical4j/model/Date.java
+++ b/src/main/java/net/fortuna/ical4j/model/Date.java
@@ -149,6 +149,13 @@ public class Date extends Iso8601 {
     protected Date(final long time, final int precision, TimeZone tz) {
         super(time, DEFAULT_PATTERN, precision, tz);
     }
+    
+    /**
+     * @param calendar a calendar value
+     */
+    public Date(final java.util.Calendar calendar) {
+        this(calendar.getTimeInMillis(), Dates.PRECISION_DAY, TimeZones.getDateTimeZone());
+    }
 
     /**
      * @param date a date value


### PR DESCRIPTION
As the java.util.Date class is more or less deprecated, and in the examples of ical4j the Calendar is just to deal with this.
It makes sense to add a constructor which takes a Calendar value.