### PR TITLE
Clarify documentation of Period.compareTo

### DIFF
--- a/src/main/java/net/fortuna/ical4j/model/Period.java
+++ b/src/main/java/net/fortuna/ical4j/model/Period.java
@@ -313,6 +313,7 @@ public class Period extends DateRange implements Comparable<Period> {
 
     /**
      * Compares the specified period with this period.
+     * First, compare the start dates.  If they are the same, compare the end dates.
      * 
      * @param arg0 a period to compare with this one
      * @return a postive value if this period is greater, negative if the other is


### PR DESCRIPTION
The definition of "greater" was ambiguous (longer period?  later start?
later end?); this pull request improves it somewhat.