### PR TITLE
Fixed NPE in DateProperty

### DIFF
--- a/src/main/java/net/fortuna/ical4j/model/property/DateProperty.java
+++ b/src/main/java/net/fortuna/ical4j/model/property/DateProperty.java
@@ -133,7 +133,7 @@ public abstract class DateProperty extends Property {
             // ensure timezone is null for VALUE=DATE properties..
             updateTimeZone(null);
             this.date = new Date(value);
-        } else {
+        } else if (value != null && !value.isEmpty()){
             this.date = new DateTime(value, timeZone);
         }
     }
@@ -166,7 +166,7 @@ public abstract class DateProperty extends Property {
      */
     @Override
     public int hashCode() {
-        return getDate().hashCode();
+        return getDate() != null ? getDate().hashCode() : 0;
     }
 
     /**

--- a/src/test/java/net/fortuna/ical4j/model/property/DatePropertyTest.java
+++ b/src/test/java/net/fortuna/ical4j/model/property/DatePropertyTest.java
@@ -31,16 +31,17 @@
  */
 package net.fortuna.ical4j.model.property;
 
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.text.ParseException;
-
 import junit.framework.TestSuite;
+import net.fortuna.ical4j.model.Date;
 import net.fortuna.ical4j.model.DateTime;
 import net.fortuna.ical4j.model.DefaultTimeZoneRegistryFactory;
 import net.fortuna.ical4j.model.Property;
 import net.fortuna.ical4j.model.PropertyTest;
 import net.fortuna.ical4j.model.TimeZoneRegistry;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.text.ParseException;
 
 /**
  * $Id$
@@ -86,6 +87,16 @@ public class DatePropertyTest extends PropertyTest {
         }
     }
 
+    public void testHashValue() throws Exception {
+        Date date = property.getDate();
+        if (date != null) {
+            assertEquals(date.hashCode(), property.hashCode());
+        } else {
+            assertEquals(0, property.hashCode());
+        }
+    }
+
+
     /**
      * @return
      */
@@ -98,11 +109,17 @@ public class DatePropertyTest extends PropertyTest {
         // dtStamp.getParameters().add(new TzId("Australia/Melbourne"));
         // dtStamp.setTimeZone(tzReg.getTimeZone("Australia/Melbourne"));
         suite.addTest(new DatePropertyTest("testCopy", dtStamp));
+        suite.addTest(new DatePropertyTest("testHashValue", dtStamp));
 
         DtStart dtStart = new DtStart(new DateTime());
         // dtStart.getParameters().add(new TzId("Australia/Melbourne"));
         dtStart.setTimeZone(tzReg.getTimeZone("Australia/Melbourne"));
         suite.addTest(new DatePropertyTest("testCopy", dtStart));
+        suite.addTest(new DatePropertyTest("testHashValue", dtStart));
+
+        DtStart dtStartEmpty = new DtStart();
+        suite.addTest(new DatePropertyTest("testCopy", dtStartEmpty));
+        suite.addTest(new DatePropertyTest("testHashValue", dtStartEmpty));
         return suite;
     }
 }


### PR DESCRIPTION
When no date is set, calling `copy()` and `hashCode()` resulted in NPE.

I stumbled upon this bug using the following ical constellation. The VALARM trigger created a date property which was null, so calling `hashValue()` on the event resulted in an NPE.

```
BEGIN:VCALENDAR
PRODID:-//Mozilla.org/NONSGML Mozilla Calendar V1.1//EN
VERSION:2.0
BEGIN:VEVENT
SUMMARY:Smry
DESCRIPTION:Dscr
LOCATION:Loc
DTSTART:20150219T180000Z
DTEND:20150219T225959Z
CLASS:DEFAULT
TRANSP:OPAQUE
BEGIN:VALARM
ACTION:DISPLAY
TRIGGER;VALUE=DURATION:-PT15M
END:VALARM
END:VEVENT
END:VCALENDAR

```