### PR TITLE
Removed concurrency issue

### DIFF
--- a/src/main/java/net/fortuna/ical4j/data/CalendarBuilder.java
+++ b/src/main/java/net/fortuna/ical4j/data/CalendarBuilder.java
@@ -148,7 +148,7 @@ public class CalendarBuilder {
 
         this.parser = parser;
         this.tzRegistry = tzRegistry;
-        this.contentHandler = new ContentHandlerImpl(ComponentFactoryImpl.getInstance(),
+        this.contentHandler = new ContentHandlerImpl(new ComponentFactoryImpl(),
                 propertyFactoryRegistry, parameterFactoryRegistry);
     }
 

--- a/src/main/java/net/fortuna/ical4j/model/Component.java
+++ b/src/main/java/net/fortuna/ical4j/model/Component.java
@@ -267,7 +267,7 @@ public abstract class Component implements Serializable {
         // Deep copy properties..
         final PropertyList newprops = new PropertyList(getProperties());
 
-        return ComponentFactoryImpl.getInstance().createComponent(getName(),
+        return new ComponentFactoryImpl().createComponent(getName(),
                 newprops);
     }
 

--- a/src/main/java/net/fortuna/ical4j/model/ComponentFactoryImpl.java
+++ b/src/main/java/net/fortuna/ical4j/model/ComponentFactoryImpl.java
@@ -46,20 +46,11 @@ import java.util.ServiceLoader;
  */
 public final class ComponentFactoryImpl extends AbstractContentFactory<ComponentFactory> {
 
-    private static ComponentFactoryImpl instance = new ComponentFactoryImpl();
-
     /**
      * Constructor made private to prevent instantiation.
      */
-    private ComponentFactoryImpl() {
+    public ComponentFactoryImpl() {
         super(ServiceLoader.load(ComponentFactory.class, ComponentFactory.class.getClassLoader()));
-    }
-
-    /**
-     * @return Returns the instance.
-     */
-    public static ComponentFactoryImpl getInstance() {
-        return instance;
     }
 
     @Override

--- a/src/test/java/net/fortuna/ical4j/data/CalendarBuilderConcurrencyTest.java
+++ b/src/test/java/net/fortuna/ical4j/data/CalendarBuilderConcurrencyTest.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) 2012, Ben Fortuna
+ * All rights reserved.
+ * <p>
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * <p>
+ * o Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ * <p>
+ * o Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ * <p>
+ * o Neither the name of Ben Fortuna nor the names of any other contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ * <p>
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.fortuna.ical4j.data;
+
+import junit.framework.TestCase;
+import net.fortuna.ical4j.model.Calendar;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * $Id: CalendarBuilderTest.java [Apr 5, 2004]
+ * <p/>
+ * Test case for iCalendarBuilder.
+ *
+ * @author benf
+ */
+public class CalendarBuilderConcurrencyTest extends TestCase {
+
+    public void testConcurrency() throws Exception {
+        final AtomicLong size = new AtomicLong();
+        ExecutorService executorService = Executors.newFixedThreadPool(100);
+        for (int i = 0; i < 100; i++) {
+            executorService.execute(new Runnable() {
+                @Override
+                public void run() {
+                    FileInputStream fis = null;
+                    try {
+                        fis = new FileInputStream("src/test/resources/samples/valid/lotr.ics");
+                        Calendar calendar = new CalendarBuilder().build(fis);
+                        size.addAndGet(calendar.getComponents().size());
+                    } catch (Exception e) {
+                        throw new RuntimeException(e.getMessage(), e);
+                    } finally {
+                        try {
+                            fis.close();
+                        } catch (IOException e) {
+                            //ignore
+                        }
+                    }
+                }
+            });
+        }
+        executorService.shutdown();
+        executorService.awaitTermination(10, TimeUnit.MINUTES);
+        assertEquals(3700, size.longValue());
+    }
+}


### PR DESCRIPTION
Building calendar was failing in concurrent environment because of static ComponentFactoryImpl reference.
If you run CalendarBuilderConcurrencyTest on the old code, it will fail.