### PR TITLE
Mark groovy and bdn as non transivive dependencies and optional in OSGi

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,7 @@ buildscript {
 
 plugins {
   id "org.sonarqube" version "1.2"
+  id "nebula.provided-base" version "3.0.3"
 }
 
 apply plugin: 'java'
@@ -20,6 +21,7 @@ apply plugin: 'maven'
 apply plugin: 'jacoco'
 apply plugin: 'signing'
 apply plugin: 'pl.allegro.tech.build.axion-release'
+apply plugin: 'nebula.optional-base'
 apply from: 'gradle/dist.gradle'
 
 sourceCompatibility = 1.7
@@ -65,9 +67,9 @@ dependencies {
             'commons-codec:commons-codec:1.9',
             'org.apache.commons:commons-lang3:3.3.2',
             'org.apache.commons:commons-collections4:4.0',
-            'org.codehaus.groovy:groovy-all:2.3.2',
-            'biz.aQute.bnd:bndlib:2.3.0',
-            'org.threeten:threetenbp:1.3.3'
+			'org.threeten:threetenbp:1.3.3'
+    compile 'org.codehaus.groovy:groovy-all:2.3.2', optional
+    compile 'biz.aQute.bnd:bndlib:2.3.0', optional
 
     testCompile 'org.spockframework:spock-core:0.7-groovy-2.0',
             'commons-io:commons-io:2.4',
@@ -96,6 +98,12 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
 task sourcesJar(type: Jar) {
     from sourceSets.main.allSource
     classifier = 'sources'
+}
+
+jar {
+    manifest {
+        instruction 'Import-Package', 'groovy.*;resolution:=optional, org.codehaus.groovy*;resolution:=optional, *'
+    }
 }
 
 artifacts {


### PR DESCRIPTION
As request in #122 we would mark groovy and bnd as maven optional (non transitive) dependencies and also marks their OSGi import package as optional.

Reference:
* https://blog.gradle.org/introducing-compile-only-dependencies
* https://github.com/gradle/gradle/issues/867
* https://docs.gradle.org/3.3/userguide/osgi_plugin.html

deployed pom.xml in our organisation maven repository
```
<?xml version="1.0" encoding="UTF-8"?>
<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
  <modelVersion>4.0.0</modelVersion>
  <groupId>org.mnode.ical4j</groupId>
  <artifactId>ical4j</artifactId>
  <version>2.0.1-develop-SNAPSHOT</version>
  ...
  <dependencies>
  ...
    <dependency>
      <groupId>org.codehaus.groovy</groupId>
      <artifactId>groovy-all</artifactId>
      <version>2.3.2</version>
      <scope>compile</scope>
      <optional>true</optional>
    </dependency>
    <dependency>
      <groupId>biz.aQute.bnd</groupId>
      <artifactId>bndlib</artifactId>
      <version>2.3.0</version>
      <scope>compile</scope>
      <optional>true</optional>
    </dependency>
  ...
</project>
```

and MANIFEST.MF
```
...
Bnd-LastModified: 1498572145640
Import-Package: groovy.lang;resolution:=optional;version="[2.3,3)",gro
 ovy.util;resolution:=optional;version="[2.3,3)",javax.xml.namespace,j
 avax.xml.parsers,javax.xml.xpath,net.fortuna.ical4j.data;version="[2.
 0,3)",net.fortuna.ical4j.model;version="[2.0,3)",net.fortuna.ical4j.m
...
Tool: Bnd-3.2.0.201605172007
```