### PR TITLE
Handle NullPointerException when tz.alias is missing #201

### DIFF
--- a/src/main/java/net/fortuna/ical4j/model/TimeZoneRegistryImpl.java
+++ b/src/main/java/net/fortuna/ical4j/model/TimeZoneRegistryImpl.java
@@ -90,7 +90,7 @@ public class TimeZoneRegistryImpl implements TimeZoneRegistry {
         try {
             aliasInputStream = ResourceLoader.getResourceAsStream("tz.alias");
         	ALIASES.load(aliasInputStream);
-        } catch (IOException e) {
+        } catch (IOException | NullPointerException e) {
             LoggerFactory.getLogger(TimeZoneRegistryImpl.class).debug(
         			"Error loading custom timezone aliases: " + e.getMessage());
         } finally {


### PR DESCRIPTION
Catch NullPointerException in TimeZoneRegistryImpl when tz.alias is missing. Fixes #201.