### PR TITLE
Fixes #265. Issue with FREQ=DAILY and  FREQ=WEEKLY in combination with BYMONTH

### DIFF
--- a/src/main/java/net/fortuna/ical4j/model/Date.java
+++ b/src/main/java/net/fortuna/ical4j/model/Date.java
@@ -34,6 +34,7 @@ package net.fortuna.ical4j.model;
 import net.fortuna.ical4j.util.CompatibilityHints;
 import net.fortuna.ical4j.util.Dates;
 import net.fortuna.ical4j.util.TimeZones;
+import org.apache.commons.lang3.builder.EqualsBuilder;
 
 import java.text.DateFormat;
 import java.text.ParseException;
@@ -196,5 +197,15 @@ public class Date extends Iso8601 {
         final DateFormat parseFormat = new SimpleDateFormat(pattern);
         parseFormat.setTimeZone(TimeZones.getDateTimeZone());
         setTime(parseFormat.parse(value).getTime());
+    }
+
+    public boolean equals(final Object arg0) {
+        // TODO: what about compareTo, before, after, etc.?
+
+        if (arg0 instanceof Date) {
+            return new EqualsBuilder().append(getTime(), ((Date) arg0).getTime())
+                    .isEquals();
+        }
+        return super.equals(arg0);
     }
 }

--- a/src/main/java/net/fortuna/ical4j/model/Recur.java
+++ b/src/main/java/net/fortuna/ical4j/model/Recur.java
@@ -886,9 +886,26 @@ public class Recur implements Serializable {
             final Calendar freqEnd = getCalendarInstance(date, true);
             increment(freqEnd);
             for (final Integer month : getMonthList()) {
+
+
+
+                if(monthlyDates.contains(date)) {
+                    continue;
+                }
+
+                if("DAILY".equals(this.frequency)) {
+                    final Calendar preRoll = getCalendarInstance(date, true);
+                    preRoll.roll(Calendar.MONTH, (month - 1) - cal.get(Calendar.MONTH));
+
+                    if (preRoll.before(cal)) {
+                        continue;
+                    }
+                }
+
                 // Java months are zero-based..
-//                cal.set(Calendar.MONTH, month.intValue() - 1);
+                // cal.set(Calendar.MONTH, month.intValue() - 1);
                 cal.roll(Calendar.MONTH, (month - 1) - cal.get(Calendar.MONTH));
+                
                 if (cal.after(freqEnd)) {
                     break; // Do not break out of the FREQ-defined boundary
                 }

--- a/src/main/java/net/fortuna/ical4j/model/Recur.java
+++ b/src/main/java/net/fortuna/ical4j/model/Recur.java
@@ -887,8 +887,6 @@ public class Recur implements Serializable {
             increment(freqEnd);
             for (final Integer month : getMonthList()) {
 
-
-
                 if(monthlyDates.contains(date)) {
                     continue;
                 }

--- a/src/main/java/net/fortuna/ical4j/model/Recur.java
+++ b/src/main/java/net/fortuna/ical4j/model/Recur.java
@@ -891,7 +891,7 @@ public class Recur implements Serializable {
                     continue;
                 }
 
-                if("DAILY".equals(this.frequency)) {
+                if("DAILY".equals(this.frequency) || "WEEKLY".equals(this.frequency)) {
                     final Calendar preRoll = getCalendarInstance(date, true);
                     preRoll.roll(Calendar.MONTH, (month - 1) - cal.get(Calendar.MONTH));
 

--- a/src/test/java/net/fortuna/ical4j/model/RecurTest.java
+++ b/src/test/java/net/fortuna/ical4j/model/RecurTest.java
@@ -852,6 +852,14 @@ public class RecurTest extends TestCase {
         suite.addTest(new RecurTest(recur, new Date("20181010"),
                 new Date("20181011"), new Date("20181231"), Value.DATE, 3));
 
+        recur = new Recur("FREQ=WEEKLY;INTERVAL=4;WKST=MO;BYMONTH=10,11,12");
+        suite.addTest(new RecurTest(recur, new Date("20181001"),
+                new Date("20181001"), new Date("20181231"), Value.DATE, 4));
+
+        recur = new Recur("FREQ=WEEKLY;INTERVAL=4;WKST=MO;BYMONTH=10,12");
+        suite.addTest(new RecurTest(recur, new Date("20181001"),
+                new Date("20181001"), new Date("20181231"), Value.DATE, 3));
+
         // rrule with bymonth and count. Should return correct number of occurrences near the end of its perioud.
         recur = new Recur("FREQ=MONTHLY;COUNT=3;INTERVAL=1;BYMONTH=1,9,10,12;BYMONTHDAY=12");
         suite.addTest(new RecurTest(recur, new DateTime("20150917T000000Z"),

--- a/src/test/java/net/fortuna/ical4j/model/RecurTest.java
+++ b/src/test/java/net/fortuna/ical4j/model/RecurTest.java
@@ -516,7 +516,18 @@ public class RecurTest extends TestCase {
 
         log.debug(dateList.toString());
     }
-    
+
+    public void testGetDailyByMonth() throws ParseException {
+        Date seed = new Date("20181010");
+        Date start = new Date("20181011");
+        Date end = new Date("20181231");
+        String rule = "FREQ=DAILY;INTERVAL=14;WKST=MO;BYMONTH=10,12";
+        Recur recur = new Recur(rule);
+        DateList dates = recur.getDates(seed, start, end, Value.DATE);
+
+        log.debug(dates.toString());
+    }
+
     /**
      * 
      */
@@ -832,13 +843,22 @@ public class RecurTest extends TestCase {
         recur = new Recur("FREQ=DAILY;COUNT=3;INTERVAL=1;BYDAY=MO,TU,WE,TH,FR");
         suite.addTest(new RecurTest(recur, new DateTime("20131215T000000Z"),
                 new DateTime("20131215T000000Z"), new DateTime("20180101T120000Z"), Value.DATE_TIME, 3));
-        
+
+        recur = new Recur("FREQ=DAILY;INTERVAL=14;WKST=MO;BYMONTH=10,12");
+        suite.addTest(new RecurTest(recur, new Date("20181010"),
+                new Date("20181011"), new Date("20181231"), Value.DATE, 3));
+
+        recur = new Recur("FREQ=DAILY;INTERVAL=22;WKST=MO;BYMONTH=10,11,12");
+        suite.addTest(new RecurTest(recur, new Date("20181010"),
+                new Date("20181011"), new Date("20181231"), Value.DATE, 3));
+
         // rrule with bymonth and count. Should return correct number of occurrences near the end of its perioud.
         recur = new Recur("FREQ=MONTHLY;COUNT=3;INTERVAL=1;BYMONTH=1,9,10,12;BYMONTHDAY=12");
         suite.addTest(new RecurTest(recur, new DateTime("20150917T000000Z"),
                 new DateTime("20160101T000000Z"), new DateTime("20160201T000000Z"), Value.DATE, 1));
         suite.addTest(new RecurTest(recur, new DateTime("20150917T000000Z"),
                 new DateTime("20160201T000000Z"), new DateTime("20160301T000000Z"), Value.DATE, 0));
+
 
         // rrule with bymonth, byday and bysetpos. Issue #39
         recur = new Recur("FREQ=MONTHLY;WKST=MO;INTERVAL=1;BYMONTH=2,3,9,10;BYMONTHDAY=28,29,30,31;BYSETPOS=-1");


### PR DESCRIPTION
This PR fixes the issue that arises when using FREQ=DAILY together with BYMONTH, as explained in #265. Also, the same thing occurs when using FREQ=WEEKLY together with BYMONTH, so that has been fixes as well.

The following has been changed:
* An equals method was added to Date class
* getMonthVariants() in Recur adds protection agains duplicates as well as it ensures special handling for FREQ=DAILY and FREQ=WEEKLY.