### PR TITLE
enforced stricter loop condition, added explanation

### DIFF
--- a/src/main/java/net/fortuna/ical4j/model/Recur.java
+++ b/src/main/java/net/fortuna/ical4j/model/Recur.java
@@ -769,11 +769,17 @@ public class Recur implements Serializable {
         int multiplier = 1;
         if (calIncField == 2 || calIncField == 1) {
             Calendar seededCal;
+            // increment up to 12 times to check for next valid occurence.
+            // as this loop only increments monthly or yearly,
+            // a monthly occurence will be found in (0,12] increments
+            // and a valid yearly recurrence will be found within (0,4]
+            // (ex. recurrence on February 29 on a leap year will find the next occurrence on the next leap year).
+            // if none found in these, return null.
             do {
                 seededCal = (Calendar) cal.clone();
                 seededCal.add(calIncField, calInterval * multiplier);
                 multiplier++;
-            } while (seededCal.get(Calendar.DAY_OF_MONTH) != cal.get(Calendar.DAY_OF_MONTH) || multiplier > 12);
+            } while (seededCal.get(Calendar.DAY_OF_MONTH) != cal.get(Calendar.DAY_OF_MONTH) && multiplier <= 12);
             if (multiplier <= 12) {
                 result = (Calendar) seededCal.clone();
             }

--- a/src/test/java/net/fortuna/ical4j/model/RecurTest.java
+++ b/src/test/java/net/fortuna/ical4j/model/RecurTest.java
@@ -851,6 +851,11 @@ public class RecurTest extends TestCase {
         suite.addTest(new RecurTest(recur, new DateTime("20200229T000000"),
                 new DateTime("20200229T000000"), new DateTime("20210228T000000")));
 
+        // test hitting limit when getting invalid next recurrence
+        recur = new Recur("FREQ=MONTHLY;BYMONTH=2;BYMONTHDAY=30;INTERVAL=1");
+        suite.addTest(new RecurTest(recur, new DateTime("20200229T000000"),
+                new DateTime("20200229T000000"), null));
+
         return suite;
     }
 }

--- a/src/test/java/net/fortuna/ical4j/model/RecurTest.java
+++ b/src/test/java/net/fortuna/ical4j/model/RecurTest.java
@@ -856,6 +856,16 @@ public class RecurTest extends TestCase {
         suite.addTest(new RecurTest(recur, new DateTime("20200229T000000"),
                 new DateTime("20200229T000000"), null));
 
+        // test hitting leap year appropriately
+        recur = new Recur("FREQ=YEARLY;BYMONTHDAY=29;INTERVAL=1");
+        suite.addTest(new RecurTest(recur, new DateTime("20200229T000000"),
+                new DateTime("20200229T000000"), new DateTime("20240229T000000")));
+
+        // test correct hit on first incrementation
+        recur = new Recur("FREQ=YEARLY;INTERVAL=4");
+        suite.addTest(new RecurTest(recur, new DateTime("20200229T000000"),
+                new DateTime("20200229T000000"), new DateTime("20240229T000000")));
+
         return suite;
     }
 }

--- a/src/test/java/net/fortuna/ical4j/model/RecurTest.java
+++ b/src/test/java/net/fortuna/ical4j/model/RecurTest.java
@@ -844,7 +844,13 @@ public class RecurTest extends TestCase {
         recur = new Recur("FREQ=MONTHLY;WKST=MO;INTERVAL=1;BYMONTH=2,3,9,10;BYMONTHDAY=28,29,30,31;BYSETPOS=-1");
         suite.addTest(new RecurTest(recur, new DateTime("20150701T000000"),
                 new DateTime("20150701T000000"), new DateTime("20150930T000000")));
-      
+
+        // test getting valid recurrence at tip of smart increment
+        // feb 29 2020 monthly with only valid month by february should return feb 28 2021
+        recur = new Recur("FREQ=MONTHLY;BYMONTH=2;INTERVAL=1");
+        suite.addTest(new RecurTest(recur, new DateTime("20200229T000000"),
+                new DateTime("20200229T000000"), new DateTime("20210228T000000")));
+
         return suite;
     }
 }


### PR DESCRIPTION
This is a fix for the changes introduced from issue #174 . Given an invalid date, after 12 trials (multiplier > 12) we should return null as no valid date is possible however the loop currently runs infinitely. A fix is included by making the condition strict to only loop when we haven't hit a valid date and we still can increment further. If we reach the valid date or pass max increments then we break and return result as null.

Previous valid conditions:
`!equal && multiplier <= 12`
`!equal && multiplier > 12`
`equal && multiplier > 12`

Now:
`!equal && multiplier <= 12`