### PR TITLE
Update javax.mail group / package dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,7 +75,7 @@ dependencies {
             'commons-codec:commons-codec:1.10',
             'org.apache.commons:commons-lang3:3.6',
             'org.apache.commons:commons-collections4:4.1',
-            'javax.mail:javax.mail-api:1.5.4'
+            'com.sun.mail:javax.mail:1.6.2'
     
     implementation 'javax.cache:cache-api:1.0.0', optional
     implementation "org.codehaus.groovy:groovy-all:$groovyVersion", optional


### PR DESCRIPTION
The javax.mail package had a group name / package name change. The actual class path stayed the same.