### PR TITLE
Fix timezones depending on system default in Recur

### DIFF
--- a/src/main/java/net/fortuna/ical4j/transform/recurrence/AbstractDateExpansionRule.java
+++ b/src/main/java/net/fortuna/ical4j/transform/recurrence/AbstractDateExpansionRule.java
@@ -2,6 +2,7 @@ package net.fortuna.ical4j.transform.recurrence;
 
 import net.fortuna.ical4j.model.Date;
 import net.fortuna.ical4j.model.DateList;
+import net.fortuna.ical4j.model.DateTime;
 import net.fortuna.ical4j.model.Recur.Frequency;
 import net.fortuna.ical4j.model.WeekDay;
 import net.fortuna.ical4j.transform.Transformer;
@@ -115,5 +116,18 @@ public abstract class AbstractDateExpansionRule implements Transformer<DateList>
         cal.setTime(date);
 
         return cal;
+    }
+
+    /**
+     * Get a DateTime from cal.getTime() with the timezone of the given reference date.
+     *
+     * @param referenceDate
+     * @param cal
+     * @return
+     */
+    protected static Date getTime(final Date referenceDate, final Calendar cal) {
+        final Date zonedDate = new DateTime(referenceDate);
+        zonedDate.setTime(cal.getTime().getTime());
+        return zonedDate;
     }
 }

--- a/src/main/java/net/fortuna/ical4j/transform/recurrence/ByDayRule.java
+++ b/src/main/java/net/fortuna/ical4j/transform/recurrence/ByDayRule.java
@@ -90,7 +90,7 @@ public class ByDayRule extends AbstractDateExpansionRule {
                 if (!dayList.stream().map(weekDay -> WeekDay.getCalendarDay(weekDay))
                         .filter(calDay -> cal.get(Calendar.DAY_OF_WEEK) == calDay)
                         .collect(Collectors.toList()).isEmpty()) {
-                    retVal.add(Dates.getInstance(cal.getTime(), type));
+                    retVal.add(Dates.getInstance(getTime(date, cal), type));
                 }
                 cal.add(Calendar.DAY_OF_WEEK, 1);
             }
@@ -117,7 +117,7 @@ public class ByDayRule extends AbstractDateExpansionRule {
                 if (!dayList.stream().map(weekDay -> WeekDay.getCalendarDay(weekDay))
                         .filter(calDay -> cal.get(Calendar.DAY_OF_WEEK) == calDay)
                         .collect(Collectors.toList()).isEmpty()) {
-                    retVal.add(Dates.getInstance(cal.getTime(), type));
+                    retVal.add(Dates.getInstance(getTime(date, cal), type));
                 }
                 cal.add(Calendar.DAY_OF_MONTH, 1);
             }
@@ -144,7 +144,7 @@ public class ByDayRule extends AbstractDateExpansionRule {
                 if (!dayList.stream().map(weekDay -> WeekDay.getCalendarDay(weekDay))
                         .filter(calDay -> cal.get(Calendar.DAY_OF_WEEK) == calDay)
                         .collect(Collectors.toList()).isEmpty()) {
-                    retVal.add(Dates.getInstance(cal.getTime(), type));
+                    retVal.add(Dates.getInstance(getTime(date, cal), type));
                 }
                 cal.add(Calendar.DAY_OF_YEAR, 1);
             }

--- a/src/main/java/net/fortuna/ical4j/transform/recurrence/ByHourRule.java
+++ b/src/main/java/net/fortuna/ical4j/transform/recurrence/ByHourRule.java
@@ -77,7 +77,7 @@ public class ByHourRule extends AbstractDateExpansionRule {
             // construct a list of possible months..
             hourList.forEach(hour -> {
                 cal.set(Calendar.HOUR_OF_DAY, hour);
-                retVal.add(Dates.getInstance(cal.getTime(), type));
+                retVal.add(Dates.getInstance(getTime(date, cal), type));
             });
             return retVal;
         }

--- a/src/main/java/net/fortuna/ical4j/transform/recurrence/ByMinuteRule.java
+++ b/src/main/java/net/fortuna/ical4j/transform/recurrence/ByMinuteRule.java
@@ -77,7 +77,7 @@ public class ByMinuteRule extends AbstractDateExpansionRule {
             // construct a list of possible minutes..
             minuteList.forEach(minute -> {
                 cal.set(Calendar.MINUTE, minute);
-                retVal.add(Dates.getInstance(cal.getTime(), type));
+                retVal.add(Dates.getInstance(getTime(date, cal), type));
             });
             return retVal;
         }

--- a/src/main/java/net/fortuna/ical4j/transform/recurrence/ByMonthDayRule.java
+++ b/src/main/java/net/fortuna/ical4j/transform/recurrence/ByMonthDayRule.java
@@ -100,7 +100,7 @@ public class ByMonthDayRule extends AbstractDateExpansionRule {
                     cal.set(Calendar.DAY_OF_MONTH, numDaysInMonth);
                     cal.add(Calendar.DAY_OF_MONTH, monthDay + 1);
                 }
-                retVal.add(Dates.getInstance(cal.getTime(), type));
+                retVal.add(Dates.getInstance(getTime(date, cal), type));
             };
             return retVal;
         }

--- a/src/main/java/net/fortuna/ical4j/transform/recurrence/ByMonthRule.java
+++ b/src/main/java/net/fortuna/ical4j/transform/recurrence/ByMonthRule.java
@@ -80,7 +80,7 @@ public class ByMonthRule extends AbstractDateExpansionRule {
                 // Java months are zero-based..
 //                cal.set(Calendar.MONTH, month - 1);
                 cal.roll(Calendar.MONTH, (month - 1) - cal.get(Calendar.MONTH));
-                retVal.add(Dates.getInstance(cal.getTime(), type));
+                retVal.add(Dates.getInstance(getTime(date, cal), type));
             });
             return retVal;
         }

--- a/src/main/java/net/fortuna/ical4j/transform/recurrence/BySecondRule.java
+++ b/src/main/java/net/fortuna/ical4j/transform/recurrence/BySecondRule.java
@@ -78,7 +78,7 @@ public class BySecondRule extends AbstractDateExpansionRule {
             // construct a list of possible seconds..
             secondList.forEach(second -> {
                 cal.set(Calendar.SECOND, second);
-                retVal.add(Dates.getInstance(cal.getTime(), type));
+                retVal.add(Dates.getInstance(getTime(date, cal), type));
             });
             return retVal;
         }

--- a/src/main/java/net/fortuna/ical4j/transform/recurrence/ByWeekNoRule.java
+++ b/src/main/java/net/fortuna/ical4j/transform/recurrence/ByWeekNoRule.java
@@ -59,7 +59,7 @@ public class ByWeekNoRule extends AbstractDateExpansionRule {
                     cal.set(Calendar.WEEK_OF_YEAR, numWeeksInYear);
                     cal.add(Calendar.WEEK_OF_YEAR, weekNo + 1);
                 }
-                weekNoDates.add(Dates.getInstance(cal.getTime(), weekNoDates.getType()));
+                weekNoDates.add(Dates.getInstance(getTime(date, cal), weekNoDates.getType()));
             }
         }
         return weekNoDates;

--- a/src/main/java/net/fortuna/ical4j/transform/recurrence/ByYearDayRule.java
+++ b/src/main/java/net/fortuna/ical4j/transform/recurrence/ByYearDayRule.java
@@ -100,7 +100,7 @@ public class ByYearDayRule extends AbstractDateExpansionRule {
                     cal.set(Calendar.DAY_OF_YEAR, numDaysInYear);
                     cal.add(Calendar.DAY_OF_YEAR, yearDay + 1);
                 }
-                retVal.add(Dates.getInstance(cal.getTime(), type));
+                retVal.add(Dates.getInstance(getTime(date, cal), type));
             }
             return retVal;
         }

--- a/src/test/groovy/net/fortuna/ical4j/model/RecurSpec.groovy
+++ b/src/test/groovy/net/fortuna/ical4j/model/RecurSpec.groovy
@@ -288,6 +288,37 @@ class RecurSpec extends Specification {
     }
 
     @Unroll
+    def 'verify recurrence rule in different system timezones: #systemTimezone'() {
+        setup: 'override platform default timezone'
+        def originalTimezone = java.util.TimeZone.getDefault()
+        java.util.TimeZone.setDefault(TimeZone.getTimeZone(systemTimezone))
+
+        and: 'parse recurrence rule'
+        def recur = new Recur(rule)
+        TimeZoneRegistry registry = TimeZoneRegistryFactory.getInstance().createRegistry()
+        def berlin = registry.getTimeZone("Europe/Berlin")
+        def startDate = new DateTime(start, berlin)
+        def endDate = new DateTime(end, berlin)
+        def expectedDates = []
+        expected.each {
+            expectedDates << new DateTime(it, berlin)
+        }
+
+        expect:
+        recur.getDates(startDate, endDate, Value.DATE_TIME) == expectedDates
+
+        cleanup:
+        java.util.TimeZone.setDefault(originalTimezone)
+
+        where:
+        systemTimezone			| rule															| start				| end				| expected
+        'Europe/Berlin'			| 'FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR,SA,SU;BYHOUR=0;BYMINUTE=5'	| '20161029T000000'	| '20161102T000000'	| ['20161029T000500', '20161030T000500', '20161031T000500', '20161101T000500']
+        'America/Phoenix'		| 'FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR,SA,SU;BYHOUR=0;BYMINUTE=5'	| '20161029T000000'	| '20161102T000000'	| ['20161029T000500', '20161030T000500', '20161031T000500', '20161101T000500']
+        'America/St_Johns'		| 'FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR,SA,SU;BYHOUR=0;BYMINUTE=5'	| '20161029T000000'	| '20161102T000000'	| ['20161029T000500', '20161030T000500', '20161031T000500', '20161101T000500']
+        'Africa/Johannesburg'	| 'FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR,SA,SU;BYHOUR=0;BYMINUTE=5'	| '20161029T000000'	| '20161102T000000'	| ['20161029T000500', '20161030T000500', '20161031T000500', '20161101T000500']
+    }
+
+    @Unroll
     def 'verify recurrence rule with a specified interval: #rule'() {
         setup: 'parse recurrence rule'
         def recur = new Recur(rule)


### PR DESCRIPTION
We found out that the system default timezone had inflcuence on the
results returned from Recur.getDates().

E.g. for FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR,SA,SU;BYHOUR=0;BYMINUTE=5
you get different results when calling getDates with periodStart and
periodEnd in timezone Europe/Berlin while running the jvm with
-Duser.timezone=America/St_Johns vs. -Duser.timezone=America/Phoenix.

This turned out to be a problem with using Calendar's getTime() method to retrieve a java.util.Date
which is then passed to Dates.getInstance() losing the Calendar's TimeZone.

I have added a test case which detects the issue.