### PR TITLE
Use UTC as default timezone for dates with null timezone

### DIFF
--- a/src/main/java/net/fortuna/ical4j/model/DateTime.java
+++ b/src/main/java/net/fortuna/ical4j/model/DateTime.java
@@ -228,6 +228,8 @@ public class DateTime extends Date {
 
 	private TimeZone timezone;
 
+	private boolean nullTimezoneUtc = false;
+
 	/**
 	 * Default constructor.
 	 */
@@ -302,7 +304,7 @@ public class DateTime extends Date {
 	 * Creates a new date-time instance from the specified value in the given
 	 * timezone. If a timezone is not specified, the default timezone (as
 	 * returned by {@link java.util.TimeZone#getDefault()}) is used.
-	 * 
+	 *
 	 * @param value
 	 *            a string representation of a date-time
 	 * @param timezone
@@ -312,9 +314,28 @@ public class DateTime extends Date {
 	 */
 	public DateTime(final String value, final TimeZone timezone)
 			throws ParseException {
+		this(value, timezone, false);
+	}
+
+	/**
+	 * Creates a new date-time instance from the specified value in the given
+	 * timezone. If a timezone is not specified, the default timezone (as
+	 * returned by {@link java.util.TimeZone#getDefault()}) is used.
+	 * 
+	 * @param value
+	 *            a string representation of a date-time
+	 * @param timezone
+	 *            the timezone for the date-time instance
+	 * @param nullTimezoneUtc treat null timezone as utc
+	 * @throws ParseException
+	 *             where the specified string is not a valid date-time
+	 */
+	public DateTime(final String value, final TimeZone timezone, boolean nullTimezoneUtc)
+			throws ParseException {
 		// setting the time to 0 since we are going to reset it anyway
 		super(0, Dates.PRECISION_SECOND, timezone != null ? timezone
-				: java.util.TimeZone.getDefault());
+				: (nullTimezoneUtc ? TimeZones.getUtcTimeZone() : java.util.TimeZone.getDefault()));
+		this.nullTimezoneUtc = nullTimezoneUtc;
 		this.time = new Time(getTime(), getFormat().getTimeZone());
 
         try {
@@ -483,8 +504,12 @@ public class DateTime extends Date {
 	private void resetTimeZone() {
 		// use GMT timezone to avoid daylight savings rules affecting floating
 		// time values..
-		getFormat().setTimeZone(TimeZone.getDefault());
-		// getFormat().setTimeZone(TimeZone.getTimeZone(TimeZones.GMT_ID));
+		if (nullTimezoneUtc) {
+			getFormat().setTimeZone(TimeZone.getTimeZone(TimeZones.GMT_ID));
+		} else {
+			getFormat().setTimeZone(TimeZone.getDefault());
+		}
+
 	}
 
 	/**

--- a/src/main/java/net/fortuna/ical4j/model/property/DateProperty.java
+++ b/src/main/java/net/fortuna/ical4j/model/property/DateProperty.java
@@ -128,16 +128,18 @@ public abstract class DateProperty extends Property {
      *                        representation
      */
     public void setValue(final String value) throws ParseException {
+        setValue(value, true);
+    }
+    public void setValue(final String value, boolean nullTimezoneUtc) throws ParseException {
         // value can be either a date-time or a date..
         if (Value.DATE.equals(getParameter(Parameter.VALUE))) {
             // ensure timezone is null for VALUE=DATE properties..
             updateTimeZone(null);
             this.date = new Date(value);
         } else if (value != null && !value.isEmpty()){
-            this.date = new DateTime(value, timeZone);
+            this.date = new DateTime(value, timeZone, nullTimezoneUtc);
         }
     }
-
     /**
      * {@inheritDoc}
      */

--- a/src/main/java/net/fortuna/ical4j/model/property/DtStart.java
+++ b/src/main/java/net/fortuna/ical4j/model/property/DtStart.java
@@ -154,7 +154,7 @@ public class DtStart extends DateProperty {
     public DtStart(final ParameterList aList, final String aValue)
             throws ParseException {
         super(DTSTART, aList, new Factory());
-        setValue(aValue);
+        setValue(aValue, aList.getParameter("TZID") != null); // Use neutral UTC to avoid collisions with localtime time conversion
     }
 
     /**

--- a/src/test/java/net/fortuna/ical4j/data/CalendarBuilderTimezoneTest.java
+++ b/src/test/java/net/fortuna/ical4j/data/CalendarBuilderTimezoneTest.java
@@ -31,7 +31,9 @@
  */
 package net.fortuna.ical4j.data;
 
+import java.io.IOException;
 import java.io.InputStream;
+import java.io.StringReader;
 
 import junit.framework.TestCase;
 import net.fortuna.ical4j.model.Calendar;
@@ -40,6 +42,7 @@ import net.fortuna.ical4j.model.ComponentList;
 import net.fortuna.ical4j.model.DateTime;
 import net.fortuna.ical4j.model.component.CalendarComponent;
 import net.fortuna.ical4j.model.component.VEvent;
+import net.fortuna.ical4j.model.property.DtEnd;
 import net.fortuna.ical4j.model.property.DtStart;
 import net.fortuna.ical4j.util.CompatibilityHints;
 
@@ -103,6 +106,111 @@ public class CalendarBuilderTimezoneTest extends TestCase {
         assertNotNull("timezone not present", dateTime.getTimeZone());
         assertEquals("timezone not correct",
                 "/softwarestudio.org/Tzfile/America/Chicago", dateTime
+                        .getTimeZone().getID());
+
+    }
+
+    public void testTwoDaylights() throws IOException, ParserException {
+
+String ical = "BEGIN:VCALENDAR\n" +
+                "VERSION:2.0\n" +
+                "PRODID:-//Test - ECPv4.9.9//NONSGML v1.0//EN\n" +
+                "CALSCALE:GREGORIAN\n" +
+                "METHOD:PUBLISH\n" +
+                "BEGIN:VTIMEZONE\n" +
+                "TZID:Europe/Amsterdam\n" +
+                "BEGIN:DAYLIGHT\n" +
+                "TZOFFSETFROM:+0100\n" +
+                "TZOFFSETTO:+0200\n" +
+                "TZNAME:CEST\n" +
+                "DTSTART:20190331T010000\n" +
+                "END:DAYLIGHT\n" +
+                "BEGIN:STANDARD\n" +
+                "TZOFFSETFROM:+0200\n" +
+                "TZOFFSETTO:+0100\n" +
+                "TZNAME:CET\n" +
+                "DTSTART:20191027T010000\n" +
+                "END:STANDARD\n" +
+                "BEGIN:DAYLIGHT\n" +
+                "TZOFFSETFROM:+0100\n" +
+                "TZOFFSETTO:+0200\n" +
+                "TZNAME:CEST\n" +
+                "DTSTART:20200329T010000\n" +
+                "END:DAYLIGHT\n" +
+                "BEGIN:STANDARD\n" +
+                "TZOFFSETFROM:+0200\n" +
+                "TZOFFSETTO:+0100\n" +
+                "TZNAME:CET\n" +
+                "DTSTART:20201025T010000\n" +
+                "END:STANDARD\n" +
+                "END:VTIMEZONE\n" +
+                "BEGIN:VEVENT\n" +
+                "DTSTART;TZID=Europe/Amsterdam:20200503T173000\n" +
+                "DTEND;TZID=Europe/Amsterdam:20200503T200000\n" +
+                "DTSTAMP:20191006T163046\n" +
+                "CREATED:20190924T180719Z\n" +
+                "LAST-MODIFIED:20191006T154131Z\n" +
+                "SUMMARY:Test summary\n" +
+                "DESCRIPTION:Test description \\n\n" +
+                "END:VEVENT\n" +
+                "BEGIN:VEVENT\n" +
+                "DTSTART;TZID=Europe/Amsterdam:20191006T190000\n" +
+                "DTEND;TZID=Europe/Amsterdam:20191006T203000\n" +
+                "DTSTAMP:20191006T163047\n" +
+                "CREATED:20190912T190803Z\n" +
+                "LAST-MODIFIED:20190918T193650Z\n" +
+                "SUMMARY:Second test summary\n" +
+                "DESCRIPTION:Second test description \\n\n" +
+                "END:VEVENT\n" +
+                "END:VCALENDAR";
+
+        StringReader in = new StringReader(ical);
+        CalendarBuilder builder = new CalendarBuilder();
+        Calendar calendar = null;
+
+        calendar = builder.build(in);
+        assertNotNull("Calendar is null", calendar);
+        ComponentList<CalendarComponent> comps = calendar.getComponents(Component.VEVENT);
+        assertEquals("2 VEVENTs not found", 2, comps.size());
+        VEvent vevent0 = (VEvent) comps.get(0);
+
+        DtStart dtstart0 = vevent0.getStartDate();
+        DateTime dateTime = (DateTime) dtstart0.getDate();
+
+        assertEquals("date value not correct", "20200503T173000", dtstart0
+                .getValue());
+        assertNotNull("timezone not present", dateTime.getTimeZone());
+        assertEquals("timezone not correct",
+                "Europe/Amsterdam", dateTime
+                        .getTimeZone().getID());
+
+        DtEnd dtend0 = vevent0.getEndDate();
+        dateTime = (DateTime) dtend0.getDate();
+         assertEquals("date value not correct", "20200503T200000", dtend0
+                .getValue());
+        assertNotNull("timezone not present", dateTime.getTimeZone());
+        assertEquals("timezone not correct",
+                "Europe/Amsterdam", dateTime
+                        .getTimeZone().getID());
+
+        VEvent vevent1 = (VEvent) comps.get(1);
+        DtStart dtstart1 = vevent1.getStartDate();
+        dateTime = (DateTime) dtstart1.getDate();
+
+        assertEquals("date value not correct", "20191006T190000", dtstart1
+                .getValue());
+        assertNotNull("timezone not present", dateTime.getTimeZone());
+        assertEquals("timezone not correct",
+                "Europe/Amsterdam", dateTime
+                        .getTimeZone().getID());
+
+        DtEnd dtend1 = vevent1.getEndDate();
+        dateTime = (DateTime) dtend1.getDate();
+         assertEquals("date value not correct", "20191006T203000", dtend1
+                .getValue());
+        assertNotNull("timezone not present", dateTime.getTimeZone());
+        assertEquals("timezone not correct",
+                "Europe/Amsterdam", dateTime
                         .getTimeZone().getID());
 
     }


### PR DESCRIPTION
Fixes daylight savings affecting floating time values and thus CalendarBuilder.build() being broken due to moving dates. 