### PR TITLE
add "VERSION:2.0" to the Calendar.toString()

### DIFF
--- a/src/main/java/net/fortuna/ical4j/model/Calendar.java
+++ b/src/main/java/net/fortuna/ical4j/model/Calendar.java
@@ -198,6 +198,8 @@ public class Calendar implements Serializable {
                 ':' +
                 VCALENDAR +
                 Strings.LINE_SEPARATOR +
+                "VERSION:2.0" + // 1.0 -> vCalendar, 2.0 -> iCalendar
+                Strings.LINE_SEPARATOR +
                 getProperties() +
                 getComponents() +
                 END +


### PR DESCRIPTION
the iCalendar specification (RFC 5545) says in section [3.7.4. Version](https://icalendar.org/iCalendar-RFC-5545/3-7-4-version.html):

> Property Name: VERSION
> ...
> Conformance: This property MUST be specified once in an iCalendar object.