### PR TITLE
Fix handling of intra-day durations that lack the T flag

### DIFF
--- a/src/main/java/net/fortuna/ical4j/model/TemporalAmountAdapter.java
+++ b/src/main/java/net/fortuna/ical4j/model/TemporalAmountAdapter.java
@@ -134,6 +134,8 @@ public class TemporalAmountAdapter implements Serializable {
         }
         else if (value.matches("([+-])?P.*(W|D)")) {
             retVal = java.time.Period.parse(value);
+        } else if (value.matches("P([+-]?[0-9]*[MHS])+")) {
+            retVal = java.time.Duration.parse("PT" + value.substring(1));
         } else {
             retVal = java.time.Duration.parse(value);
         }


### PR DESCRIPTION
Durations that did not parse correctly in our first sample set:
DURATION:P10M
DURATION:P115M
DURATION:P15M
DURATION:P30M
DURATION:P45M
DURATION:P60M
DURATION:P80M
DURATION:P90M