### PR TITLE
Change default implementation of TimeZoneCache to Map-based variant.

### DIFF
--- a/src/main/java/net/fortuna/ical4j/model/TimeZoneLoader.java
+++ b/src/main/java/net/fortuna/ical4j/model/TimeZoneLoader.java
@@ -30,7 +30,8 @@ public class TimeZoneLoader {
 
     private static final String TZ_CACHE_IMPL = "net.fortuna.ical4j.timezone.cache.impl";
 
-    private static final String DEFAULT_TZ_CACHE_IMPL = "net.fortuna.ical4j.util.JCacheTimeZoneCache";
+    // Use the Map-based TimeZoneCache by default
+    private static final String DEFAULT_TZ_CACHE_IMPL = "net.fortuna.ical4j.util.MapTimeZoneCache";
 
     private static final String MESSAGE_MISSING_DEFAULT_TZ_CACHE_IMPL = "Error loading default cache implementation. Please ensure the JCache API dependency is included in the classpath, or override the cache implementation (e.g. via configuration: net.fortuna.ical4j.timezone.cache.impl=net.fortuna.ical4j.util.MapTimeZoneCache)";
 


### PR DESCRIPTION
The Map-based TimeZoneCache-Implementation will be used by default now.
Set SystemProperty net.fortuna.ical4j.timezone.cache.impl to "net.fortuna.ical4j.util.JCacheTimeZoneCache" and provide a JCache-Implentation in the classpath to use JCache.

This should fix https://github.com/ical4j/ical4j/issues/195 as well.