### PR TITLE
Make sure tests are run with UTC timezone as default

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -22,7 +22,7 @@ jobs:
         java-version: ${{ matrix.jdk }}
     - uses: eskatos/gradle-command-action@v1
       with:
-        arguments: check
+        arguments: check --console=plain --warning-mode all
 
   publish:
     name: Publish Artifact

--- a/build.gradle
+++ b/build.gradle
@@ -85,12 +85,16 @@ dependencies {
 
 test {
     useJUnitPlatform()
+
+    finalizedBy jacocoTestReport // Ensure Jacoco is run after tests have completed
+
+    jvmArgs = [ "-Duser.timezone=UTC" ] // Some tests require default timezone to be UTC
 }
 
 jacocoTestReport {
     reports {
-        xml.enabled true
-        html.enabled 'true' == jacoco_htmlReport
+        xml.required = true
+        html.required = jacoco_htmlReport == 'true'
     }
 }
 

--- a/src/test/groovy/net/fortuna/ical4j/model/DateTimeSpec.groovy
+++ b/src/test/groovy/net/fortuna/ical4j/model/DateTimeSpec.groovy
@@ -32,7 +32,6 @@
 package net.fortuna.ical4j.model
 
 import net.fortuna.ical4j.model.component.VTimeZone
-import spock.lang.Ignore
 import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -156,7 +155,6 @@ class DateTimeSpec extends Specification {
         dateTimeString << ['20110327T000000']
     }
 
-    @Ignore
     @Unroll
     def 'verify parse failure for invalid dates: #dateTimeString'() {
         when:


### PR DESCRIPTION
in follow up to the previous PR. This makes sure those tests will pass on any machine by setting default timezone to UTC when tests are run. I also fixed some deprecation warnings for Jacoco and made sure that reports are generated and enabled a test that is working