### PR TITLE
fix for com.sun.mail lib import issue instead of jakarta mail

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ dependencies {
             "commons-codec:commons-codec:$commonsCodecVersion",
             "org.apache.commons:commons-lang3:$commonsLangVersion",
             "org.apache.commons:commons-collections4:$commonsCollectionsVersion",
-            'com.sun.mail:javax.mail:1.6.2'
+            'com.sun.mail:jakarta.mail:2.0.1'
 
     // optional timezone caching..
     implementation 'javax.cache:cache-api:1.1.1', optional

--- a/src/main/java/net/fortuna/ical4j/model/parameter/Email.java
+++ b/src/main/java/net/fortuna/ical4j/model/parameter/Email.java
@@ -1,13 +1,12 @@
 package net.fortuna.ical4j.model.parameter;
 
+import jakarta.mail.internet.AddressException;
+import jakarta.mail.internet.InternetAddress;
 import net.fortuna.ical4j.model.Content;
 import net.fortuna.ical4j.model.Encodable;
 import net.fortuna.ical4j.model.Parameter;
 import net.fortuna.ical4j.model.ParameterFactory;
 import net.fortuna.ical4j.util.CompatibilityHints;
-
-import javax.mail.internet.AddressException;
-import javax.mail.internet.InternetAddress;
 
 import static net.fortuna.ical4j.util.CompatibilityHints.KEY_RELAXED_PARSING;
 

--- a/src/test/groovy/net/fortuna/ical4j/model/parameter/EmailTest.groovy
+++ b/src/test/groovy/net/fortuna/ical4j/model/parameter/EmailTest.groovy
@@ -3,8 +3,8 @@ package net.fortuna.ical4j.model.parameter
 import net.fortuna.ical4j.AbstractBuilderTest
 import net.fortuna.ical4j.model.Calendar
 import net.fortuna.ical4j.util.CompatibilityHints
+import jakarta.mail.internet.AddressException;
 
-import javax.mail.internet.AddressException
 
 /**
  * Created by fortuna on 6/09/15.


### PR DESCRIPTION
as in the issue, the import of com.sun.mail is old, it became jakarta.mail so we have to import jakarta mail lib since 2019