### PR TITLE
update GH Actions to use v3

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        jdk: [ '8', '11', '17', '18', '20' ]
+        jdk: [ '8', '11', '17', '19' ] # Gradle cannot support JDK 20 yet
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -11,17 +11,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        jdk: [ '8', '11', '17', '18' ]
+        jdk: [ '8', '11', '17', '18', '20' ]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
 
     - name: Set up JDK ${{ matrix.jdk }}
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v3
       with:
+        distribution: temurin
         java-version: ${{ matrix.jdk }}
+        cache: 'gradle'
+
     - uses: eskatos/gradle-command-action@v1
       with:
         arguments: check --console=plain --warning-mode all
@@ -32,14 +35,16 @@ jobs:
     if: ${{ needs.gradle.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
 
-    - name: Set up JDK 11
-      uses: actions/setup-java@v1
+    - name: Set up JDK 8
+      uses: actions/setup-java@v3
       with:
-        java-version: 11
+        distribution: temurin
+        java-version: 8
+        cache: 'gradle'
 
     - uses: eskatos/gradle-command-action@v1
       with:

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ joolVersion = 0.9.14
 jparsecVersion = 3.1
 everitJsonSchemaVersion = 1.14.1
 
-groovyVersion = 3.0.10
+groovyVersion = 3.0.17
 bndVersion = 6.3.1
 tagsoupVersion = 1.2.1
 jcacheVersion = 2.6.1.Final

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
- updated some GH actions to use more recent versions
- updated gradle wrapper to 7.6 (using v8 will require more changes)
- bumped Groovy to 3.0.17 (to get build working on JDK 19)
- bumped max JDK version used to be 19 (gradle doesn't support JDK 20 yet)