### PR TITLE
Text property (e.g. DESCRIPTION) escapes DQUOTE without need

### DIFF
--- a/src/main/java/net/fortuna/ical4j/model/PropertyCodec.java
+++ b/src/main/java/net/fortuna/ical4j/model/PropertyCodec.java
@@ -26,7 +26,7 @@ public class PropertyCodec implements StringEncoder, StringDecoder {
     private static final Pattern NEWLINE_EX = Pattern.compile("\r?\n");
 
     // matches an unencoded special character..
-    private static final Pattern SPECIALCHAR_EX = Pattern.compile("([,;\"])");
+    private static final Pattern SPECIALCHAR_EX = Pattern.compile("([,;])");
 
     // matches an encoded backslash character..
     private static final Pattern ENCODED_BACKSLASH_EX = Pattern.compile(ENCODED_BACKSLASH);

--- a/src/test/groovy/net/fortuna/ical4j/model/PropertyCodecTest.groovy
+++ b/src/test/groovy/net/fortuna/ical4j/model/PropertyCodecTest.groovy
@@ -48,4 +48,13 @@ class PropertyCodecTest extends Specification {
         '\r\n'                                          | '\\n'
         'test N\n test RN\r\n test NR\n\r test R\r end' | 'test N\\n test RN\\n test NR\\n\r test R\r end'
     }
+
+    def 'verify Dquote escaping'() {
+        expect:
+        PropertyCodec.INSTANCE.encode(value) == encodedValue
+
+        where:
+        value            | encodedValue
+        'Test \"quote\"' | 'Test \"quote\"'
+    }
 }


### PR DESCRIPTION
I've removed `"` from the list of escaping characters, and added a test to make sure it's not being escaped. See #641 for more information.

Fixes #641.