### PR TITLE
relates to [#632,#658]: highlighting some changes that will be needed when updating to Gradle 8.x

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -11,10 +11,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        jdk: [ '8', '11', '17', '19' ] # Gradle cannot support JDK 20 yet
+        jdk: [ '8', '11', '17', '20' ] # Gradle cannot support JDK 21 yet
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
 
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-java@v3
         with:
           distribution: temurin

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        jdk: [ '8', '11', '17', '20' ] # Gradle cannot support JDK 21 yet
+        jdk: [ '11', '17', '21' ] # removed JDK due to plugin errors
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/run-build.yml
+++ b/.github/workflows/run-build.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-java@v3
         with:
           distribution: temurin

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 

--- a/build.gradle
+++ b/build.gradle
@@ -16,8 +16,8 @@ plugins {
     id 'signing'
     id 'org.hidetake.ssh' version '2.11.2'
     id "pl.allegro.tech.build.axion-release" version "1.15.1"
-    id "nebula.provided-base" version "7.0.0"
-    id "nebula.optional-base" version "7.0.0"
+    id "com.netflix.nebula.provided-base" version "10.0.0" // note that nebula.provided-base plugin does nothing. see: #658
+    id "com.netflix.nebula.optional-base" version "10.0.0" // note that nebula.optional-base plugin does nothing. see: #658
     id "com.palantir.revapi" version "1.7.0"
     id "net.ltgt.errorprone" version "2.0.2" apply false
     id "biz.aQute.bnd.builder" version "$bndVersion"
@@ -53,20 +53,20 @@ dependencies {
     }
 
     // optional timezone caching..
-    implementation 'javax.cache:cache-api:1.1.1', optional
+    implementation 'javax.cache:cache-api:1.1.1' // was previously optional but optional dependencies are no longer supported by Gradle. Should use feature varients. See #632
 
     // optional support for non-Gregorian chronologies..
-    implementation "org.threeten:threeten-extra:$threetenExtraVersion", optional
+    implementation "org.threeten:threeten-extra:$threetenExtraVersion" // was previously optional but optional dependencies are no longer supported by Gradle. Should use feature varients. See #632
 
     // optional parser for filter expressions..
-    implementation "org.jparsec:jparsec:$jparsecVersion", optional
+    implementation "org.jparsec:jparsec:$jparsecVersion" // was previously optional but optional dependencies are no longer supported by Gradle. Should use feature varients. See #632
 
     // optional groovy DSL for calendar builder..
-    implementation "org.codehaus.groovy:groovy:$groovyVersion", optional
-    implementation "org.codehaus.groovy:groovy-dateutil:$groovyVersion", optional
+    implementation "org.codehaus.groovy:groovy:$groovyVersion" // was previously optional but optional dependencies are no longer supported by Gradle. Should use feature varients. See #632
+    implementation "org.codehaus.groovy:groovy-dateutil:$groovyVersion" // was previously optional but optional dependencies are no longer supported by Gradle. Should use feature varients. See #632
 
     // optional JSON schema validation for structured-data..
-    implementation "com.github.erosb:json-sKema:$jsonSkemaVersion", optional
+    implementation "com.github.erosb:json-sKema:$jsonSkemaVersion" // was previously optional but optional dependencies are no longer supported by Gradle. Should use feature varients. See #632
 
     compileOnly "biz.aQute.bnd:biz.aQute.bndlib:$bndVersion"
 
@@ -97,12 +97,24 @@ dependencies {
 test {
     useJUnitPlatform()
 
-    finalizedBy jacocoTestReport // Ensure Jacoco is run after tests have completed
+    finalizedBy jacocoTestCoverageVerification, jacocoTestReport // Ensure Jacoco is run after tests have completed
 
     jvmArgs = [ "-Duser.timezone=UTC" ] // Some tests require default timezone to be UTC
 }
 
+jacocoTestCoverageVerification {
+    dependsOn test
+    violationRules {
+        rule {
+            limit {
+                minimum = 0.7
+            }
+        }
+    }
+}
+
 jacocoTestReport {
+    dependsOn test
     reports {
         xml.required = true
         html.required = jacoco_htmlReport == 'true'

--- a/build.gradle
+++ b/build.gradle
@@ -14,8 +14,8 @@ plugins {
     id 'maven-publish'
     id 'jacoco'
     id 'signing'
-    id 'org.hidetake.ssh' version '2.11.2'
-    id "pl.allegro.tech.build.axion-release" version "1.15.1"
+    id 'org.hidetake.ssh' version '2.11.2' // errors when using Gradle 8.* with JDK 8
+    id "pl.allegro.tech.build.axion-release" version "1.15.5" // errors when using Gradle 8.* with JDK 8 (https://github.com/allegro/axion-release-plugin/issues?q=is%3Aissue+is%3Aopen+%22Gradle+8%22+in%3Atitle)
     id "com.netflix.nebula.provided-base" version "10.0.0" // note that nebula.provided-base plugin does nothing. see: #658
     id "com.netflix.nebula.optional-base" version "10.0.0" // note that nebula.optional-base plugin does nothing. see: #658
     id "com.palantir.revapi" version "1.7.0"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Please treat this PR as for information only. I was taking a look at what breaking changes to expect when updating Gradle to latest v8 (8.4 currently) so that builds can be done with JDK 21.

Issues #632 and #658 are opened already for related issues that should be dealt with in individual PR's prior to updating the Gradle version.
