### PR TITLE
Add native-image metadata for GraalVM

### DIFF
--- a/src/main/resources/META-INF/native-image/com.fortuna.ical4j/reflect-config.json
+++ b/src/main/resources/META-INF/native-image/com.fortuna.ical4j/reflect-config.json
@@ -1,0 +1,11 @@
+[
+  {
+    "name": "net.fortuna.ical4j.util.MapTimeZoneCache",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  }
+]

--- a/src/main/resources/META-INF/native-image/com.fortuna.ical4j/resource-config.json
+++ b/src/main/resources/META-INF/native-image/com.fortuna.ical4j/resource-config.json
@@ -1,0 +1,7 @@
+{
+  "resources": [
+      {
+        "pattern": "net/fortuna/ical4j/model/tz\\.alias"
+      }
+  ]
+}


### PR DESCRIPTION
This allows ical4j to work out of the box with Oracle [GraalVM](https://graalvm.org)'s native compilation.