### PR TITLE
Align groovy and hamcrest versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -96,6 +96,8 @@ dependencies {
     testImplementation platform("org.spockframework:spock-bom:$spockVersion"),
             "org.spockframework:spock-core"
 
+    testImplementation "org.hamcrest:hamcrest-core:$hamcrestVersion"
+
     // testcontainers
     testImplementation "org.testcontainers:testcontainers:$testcontainersVersion",
             "org.testcontainers:spock:$testcontainersVersion"

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,13 +8,17 @@ threetenExtraVersion = 1.8.0
 jparsecVersion = 3.1
 jsonSkemaVersion = 0.11.0
 
-groovyVersion = 3.0.21
+groovyVersion = 3.0.22
 bndVersion = 6.3.1
 tagsoupVersion = 1.2.1
 jcacheVersion = 2.6.1.Final
 #junitVersion = 4.13
 junitVintageVersion = 5.10.2
-spockVersion = 2.4-M1-groovy-3.0
+# spock pulls in hamcrest 2.2, but junit pulls in
+# hamcrest-core 1.3, so explicitly load hamcrest-core 2.2
+# to make versions match
+hamcrestVersion = 2.2
+spockVersion = 2.4-M4-groovy-3.0
 testcontainersVersion = 1.19.8
 
 jacoco_htmlReport = true


### PR DESCRIPTION
spock, groovy and junit were disagreeing on versions, leading to split package errors when building on Nix.

Fixes #725