### PR TITLE
Change expectation of RecurSpec for intervals

### DIFF
--- a/src/test/groovy/net/fortuna/ical4j/model/RecurSpec.groovy
+++ b/src/test/groovy/net/fortuna/ical4j/model/RecurSpec.groovy
@@ -304,7 +304,8 @@ class RecurSpec extends Specification {
 
         where:
         rule								| start			| end			| expected
-        'FREQ=WEEKLY;INTERVAL=2;BYDAY=SU'	| '20110101'	| '20110201'	| ['20110109', '20110123']
+        'FREQ=WEEKLY;INTERVAL=2;BYDAY=SU'	| '20110102'	| '20110201'	| ['20110102', '20110116', '20110130']
+        'FREQ=WEEKLY;INTERVAL=2;BYDAY=SU'	| '20101226'	| '20110201'	| ['20101226', '20110109', '20110123']
     }
 
     @Unroll


### PR DESCRIPTION
https://www.rfc-editor.org/rfc/rfc5545#section-3.8.5.3 says:
    
```
The "DTSTART" property
value SHOULD be synchronized with the recurrence rule, if
specified.  The recurrence set generated with a "DTSTART" property
value not synchronized with the recurrence rule is undefined.
```
    
... so pick a start date that is on a Sunday.
   
This way the behavior of this test also no longer depends
on on which day of the week the week starts.
    
Fixes #727