### PR TITLE
Run Gradle CI on PRs

### DIFF
--- a/.github/workflows/run-build.yml
+++ b/.github/workflows/run-build.yml
@@ -3,7 +3,7 @@
 
 name: Java CI with Gradle
 
-on: [push]
+on: [push, pull_request]
 
 permissions: read-all
 


### PR DESCRIPTION
`push` only triggers for branches within the repo, adding `pull_request` makes it also run for external PRs