### PR TITLE
Fixate timezone in P1D test

### DIFF
--- a/src/main/java/net/fortuna/ical4j/model/TemporalAmountAdapter.java
+++ b/src/main/java/net/fortuna/ical4j/model/TemporalAmountAdapter.java
@@ -224,7 +224,7 @@ public class TemporalAmountAdapter implements Serializable {
      * Returns a date representing the end of this duration from the specified start date.
      * @param start the date to start the duration
      * @return the end of the duration as a date
-     * @deprecated use <code>Instant.from(getDuration().addTo(start))</code>, where start is a {@link Temporal}
+     * @deprecated use <code>getDuration().addTo(start)</code>, where start is a {@link Temporal}
      */
     @Deprecated
     public final Date getTime(final Date start) {

--- a/src/test/groovy/net/fortuna/ical4j/model/TemporalAmountAdapterTest.groovy
+++ b/src/test/groovy/net/fortuna/ical4j/model/TemporalAmountAdapterTest.groovy
@@ -96,12 +96,24 @@ class TemporalAmountAdapterTest extends Specification {
 
     @Unroll
     def 'verify duration plus time operations: #duration'() {
+        setup: 'Override default timezone for test consistency'
+        def originalTimezone = TimeZone.default
+        TimeZone.default = TimeZone.getTimeZone(tz)
+
         expect: 'derived end time value equals expected'
         TemporalAmountAdapter.from(new Dur(duration)).getTime(new DateTime(start)) == new DateTime(expectedEnd)
 
+        cleanup:
+        TimeZone.default = originalTimezone
+
         where:
-        duration	| start				| expectedEnd
-        'P1D' | '20110326T110000' | '20110327T110000'
+        duration | start             | expectedEnd       | tz
+        'P1D'    | '20110326T110000' | '20110327T110000' | 'Australia/Melbourne'
+        // Because the night of 20110326 is the rollover between CET and CEST
+        // in Europe/Amsterdam, the current implementation of `getTime` arrives
+        // at 12:00 the next day rather than 11:00.
+        // This is arguably incorrect, but perhaps OK for a deprecated method:
+        'P1D'    | '20110326T110000' | '20110327T120000' | 'Europe/Amsterdam'
     }
 
     @Unroll


### PR DESCRIPTION
Closes #731

This confirms the problem is timezone-related: the test succeeds when setting the default timezone to
`Australia/Melbourne` and fails when it's set to
`Europe/Amsterdam`. Before applying this change, however we should double-check that it's OK that this behavior depends on the default timezone, and that it's not a bug that it depends on it.