### PR TITLE
Set an arbitrary period length for calculating recurrences

### DIFF
--- a/src/main/java/net/fortuna/ical4j/model/ZoneRulesBuilder.java
+++ b/src/main/java/net/fortuna/ical4j/model/ZoneRulesBuilder.java
@@ -97,10 +97,7 @@ public class ZoneRulesBuilder {
                 } else {
                     startDate = (LocalDateTime) start.getDate();
                 }
-                LocalDateTime periodEnd = LocalDateTime.now();
-                if (periodEnd.isBefore(startDate)) {
-                    periodEnd = startDate.plusYears(5);
-                }
+                final LocalDateTime periodEnd = LocalDateTime.now().plusYears(5);
                 observance.calculateRecurrenceSet(new Period<>(startDate, periodEnd)).forEach( p -> {
                     transitions.add(ZoneOffsetTransition.of(LocalDateTime.from(p.getStart()),
                             offsetFrom.get().getOffset(), offsetTo.getOffset()));


### PR DESCRIPTION
This PR is a potential fix for #746. 

We were experiencing issues when a calculating recurrence set in the future. After some investigation, we have found that this occurs due to the `periodEnd` in `buildDSTTransitions` being set to `LocalDateTime.now()`. The DST transitions would only generate up until the current time, and so future recurrence sets have an incorrect offset. This is why we experienced the behaviour in #746.

The changes in this PR fix the immediate issue that we are seeing, but we might be missing some context behind the existing logic (i.e. only setting the arbitrary period length when `DTSTART` is after now).

cc: @william-coulter