### PR TITLE
Fallback to GlobalZone if TZID not in VTIMEZONE

### DIFF
--- a/src/main/java/net/fortuna/ical4j/model/parameter/TzId.java
+++ b/src/main/java/net/fortuna/ical4j/model/parameter/TzId.java
@@ -35,6 +35,7 @@ import net.fortuna.ical4j.model.*;
 import net.fortuna.ical4j.util.Strings;
 
 import java.time.ZoneId;
+import java.time.DateTimeException;
 
 /**
  * $Id$ [18-Apr-2004]
@@ -80,10 +81,14 @@ public class TzId extends Parameter implements Encodable {
      */
     public ZoneId toZoneId(TimeZoneRegistry timeZoneRegistry) {
         if (timeZoneRegistry != null && !timeZoneRegistry.getZoneRules().isEmpty()) {
-            return timeZoneRegistry.getZoneId(getValue());
-        } else {
-            return TimeZoneRegistry.getGlobalZoneId(getValue());
+            try {
+                return timeZoneRegistry.getZoneId(getValue());
+            } catch (DateTimeException e) {
+                // fails with "Unknown timezone identifier" if tzid not in VTIMEZONE
+                // fall through to try GlobalZone instead
+            }
         }
+        return TimeZoneRegistry.getGlobalZoneId(getValue());
     }
 
     /**

--- a/src/test/groovy/net/fortuna/ical4j/model/VTimezoneTest.groovy
+++ b/src/test/groovy/net/fortuna/ical4j/model/VTimezoneTest.groovy
@@ -1,0 +1,77 @@
+/*
+ *  Copyright (c) 2022, Ben Fortuna
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   o Redistributions of source code must retain the above copyright
+ *  notice, this list of conditions and the following disclaimer.
+ *
+ *   o Redistributions in binary form must reproduce the above copyright
+ *  notice, this list of conditions and the following disclaimer in the
+ *  documentation and/or other materials provided with the distribution.
+ *
+ *   o Neither the name of Ben Fortuna nor the names of any other contributors
+ *  may be used to endorse or promote products derived from this software
+ *  without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ *  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ *  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ *  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ *  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+package net.fortuna.ical4j.model
+
+import net.fortuna.ical4j.AbstractBuilderTest
+import net.fortuna.ical4j.model.Calendar
+
+// test to demonstrate https://github.com/ical4j/ical4j/issues/744
+
+class VTimezoneTest extends AbstractBuilderTest {
+    def 'test TZID not in VTIMEZONE'() {
+        given: 'a calendar with TZID not in VTIMEZONE'
+        String calendarString = '''BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//ABC Corporation//NONSGML My Product//EN
+METHOD:PUBLISH
+BEGIN:VTIMEZONE
+TZID:Asia/Tokyo
+BEGIN:STANDARD
+DTSTART:19700101T000000
+TZOFFSETFROM:+0900
+TZOFFSETTO:+0900
+END:STANDARD
+END:VTIMEZONE
+BEGIN:VEVENT
+DTSTART;TZID=Asia/Tokyo:20191006T190000
+DTEND;TZID=Asia/Tokyo:20191006T203000
+DTSTAMP:20191006T163047Z
+SUMMARY:Event with TZ Tokyo defined in VTIMEZONE
+END:VEVENT
+BEGIN:VEVENT
+DTSTART;TZID=America/New_York:20250304T180000
+DTEND;TZID=America/New_York:20250304T210000
+DTSTAMP:20250304T163046Z
+SUMMARY:Event with TZ New_York NOT defined in VTIMEZONE
+END:VEVENT
+END:VCALENDAR
+'''
+        when: 'the input is parsed'
+        Calendar calendar = builder.build(new StringReader(calendarString))
+
+        then: 'a valid calendar is realised'
+
+        println "Parsed calendar: " + calendar
+    }
+}


### PR DESCRIPTION
fixes #744 

If VTIMEZONE is defined but TZID is not in VTIMEZONE, fallback to GlobalZone, rather than throwing exception.

I've added a new test-case `model/VTimezoneTest.groovy`, which fails without the fix to `TzId.java`