### PR TITLE
Fix issue-800 - Incorrect Folding of Multibyte Characters Causes Corrupted Output 

### DIFF
--- a/src/main/java/net/fortuna/ical4j/data/FoldingWriter.java
+++ b/src/main/java/net/fortuna/ical4j/data/FoldingWriter.java
@@ -101,7 +101,7 @@ public class FoldingWriter extends FilterWriter {
      */
     @Override
     public final void write(final char[] buffer, final int offset,
-                            final int length) throws IOException {
+            final int length) throws IOException {
         final int maxIndex = offset + length - 1;
         for (int i = offset; i <= maxIndex; i++) {
 
@@ -111,12 +111,15 @@ public class FoldingWriter extends FilterWriter {
                         + lineLength + "]");
             }
 
-            // check for fold first so we don't unnecessarily fold after
-            // no more data..
-            if (lineLength >= foldLength) {
-                super.write(FOLD_PATTERN, 0, FOLD_PATTERN.length);
+            // Detect surrogate pairs (such as emojis) to avoid splitting them.
+            boolean isHighSurrogate = Character.isHighSurrogate(buffer[i]);
+            boolean hasLowSurrogate = i < maxIndex && Character.isLowSurrogate(buffer[i + 1]);
 
-                // re-initialise to 1 to account for the space in fold pattern..
+            // If we are at the fold limit and have a surrogate pair, fold before writing
+            // the complete pair.
+            // OR Normal folding when the limit is reached"
+            if (lineLength >= foldLength - 1 && isHighSurrogate && hasLowSurrogate || lineLength >= foldLength) {
+                super.write(FOLD_PATTERN, 0, FOLD_PATTERN.length);
                 lineLength = 1;
             }
 

--- a/src/test/java/net/fortuna/ical4j/data/FoldingWriterTest.java
+++ b/src/test/java/net/fortuna/ical4j/data/FoldingWriterTest.java
@@ -31,13 +31,14 @@
  */
 package net.fortuna.ical4j.data;
 
-import junit.framework.TestCase;
-import net.fortuna.ical4j.util.Strings;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.io.StringWriter;
+
+import org.junit.jupiter.api.Test;
+
+import net.fortuna.ical4j.util.Strings;
 
 /**
  * $Id$
@@ -48,21 +49,82 @@ import java.io.StringWriter;
  *
  * @author Ben Fortuna
  */
-public class FoldingWriterTest extends TestCase {
+class FoldingWriterTest {
 
-    private static final Logger LOG = LoggerFactory.getLogger(FoldingWriterTest.class);
+    @Test
+    void testLineLengthAppend() throws IOException {
 
-    /**
-     * Test writing a line equal to fold length.
-     */
-    public void testLineLength73() throws IOException {
         StringWriter sw = new StringWriter();
-        FoldingWriter writer = new FoldingWriter(sw);
-        writer.write("BEGIN:VCALENDAR");
-        writer.write(Strings.LINE_SEPARATOR);
-        writer.write("PRODID:-//Open Source Applications Foundation//NONSGML Scooby Server//EN");
-        writer.write(Strings.LINE_SEPARATOR);
-        writer.write("VERSION:2.0");
-        LOG.info(sw.getBuffer().toString());
+        try (FoldingWriter writer = new FoldingWriter(sw, 20)) {
+            for (int i = 0; i < 25; i++) {
+                writer.write(Integer.toString(i % 10));
+            }
+            assertEquals("01234567890123456789" + Strings.LINE_SEPARATOR + " 01234", sw.getBuffer().toString());
+        }
     }
+
+    @Test
+    void testLineLength73() throws IOException {
+        StringWriter sw = new StringWriter();
+
+        try (FoldingWriter writer = new FoldingWriter(sw)) {
+            writer.write("BEGIN:VCALENDAR");
+            writer.write(Strings.LINE_SEPARATOR);
+            writer.write("PRODID:-//Open Source Applications Foundation//NONSGML Scooby Server//EN");
+            writer.write(Strings.LINE_SEPARATOR);
+            writer.write("VERSION:2.0");
+
+            assertEquals("BEGIN:VCALENDAR"
+                    + Strings.LINE_SEPARATOR
+                    + "PRODID:-//Open Source Applications Foundation//NONSGML Scooby Server//EN"
+                    + Strings.LINE_SEPARATOR
+                    + "VERSION:2.0",
+                    sw.getBuffer().toString());
+        }
+    }
+
+    @Test
+    void testLineLength73Fold() throws IOException {
+        StringWriter sw = new StringWriter();
+
+        try (FoldingWriter writer = new FoldingWriter(sw)) {
+            writer.write("BEGIN:VCALENDAR");
+            writer.write(Strings.LINE_SEPARATOR);
+            writer.write("PRODID:-//Open Source Applications Foundation//NONSGML Scooby Server Application//EN");
+            writer.write(Strings.LINE_SEPARATOR);
+            writer.write("VERSION:2.0");
+
+            assertEquals("BEGIN:VCALENDAR"
+                    + Strings.LINE_SEPARATOR
+                    + "PRODID:-//Open Source Applications Foundation//NONSGML Scooby Server Appl"
+                    + Strings.LINE_SEPARATOR
+                    + " ication//EN"
+                    + Strings.LINE_SEPARATOR
+                    + "VERSION:2.0",
+                    sw.getBuffer().toString());
+        }
+    }
+
+    @Test
+    void testMultibyteCharacterFolding() throws IOException {
+
+        StringBuilder longText = new StringBuilder();
+        for (int i = 0; i < 25; i++) {
+            longText.append("🙂");
+        }
+
+        StringWriter sw = new StringWriter();
+        try (FoldingWriter writer = new FoldingWriter(sw, 20)) {
+
+            writer.write(longText.toString());
+
+            assertEquals("🙂🙂🙂🙂🙂🙂🙂🙂🙂🙂"
+                    + Strings.LINE_SEPARATOR
+                    + " 🙂🙂🙂🙂🙂🙂🙂🙂🙂"
+                    + Strings.LINE_SEPARATOR
+                    + " 🙂🙂🙂🙂🙂🙂",
+                    sw.getBuffer().toString());
+        }
+    }
+
 }


### PR DESCRIPTION
Fix #800 
Add test for multibyte character folding

Adds a new unit test `testMultibyteCharacterFolding()` to verify that the FoldingWriter 
correctly handles multibyte characters (like emoji) when performing line folding. The test ensures:

- Proper folding of strings containing emoji characters
- Correct line length handling with multibyte characters

This enhancement improves test coverage for Unicode/multibyte character support in the iCal4j library.