### PR TITLE
Fix all-day event end date calculation using Period instead of Duration

### DIFF
--- a/src/main/java/net/fortuna/ical4j/model/component/VEvent.java
+++ b/src/main/java/net/fortuna/ical4j/model/component/VEvent.java
@@ -529,10 +529,10 @@ public class VEvent extends CalendarComponent implements Prototype<VEvent>, Comp
                     vEventDuration = duration.get();
                 } else if (dtStart.get().getParameter(Parameter.VALUE).equals(Optional.of(Value.DATE_TIME))) {
                     // If "DTSTART" is a DATE-TIME, then the event's duration is zero (see: RFC 5545, 3.6.1 Event Component)
-                    vEventDuration = new Duration(java.time.Duration.ZERO);
+                    vEventDuration = new Duration(java.time.Period.ZERO);
                 } else {
                     // If "DTSTART" is a DATE, then the event's duration is one day (see: RFC 5545, 3.6.1 Event Component)
-                    vEventDuration = new Duration(java.time.Duration.ofDays(1));
+                    vEventDuration = new Duration(java.time.Period.ofDays(1));
                 }
 
                 Optional<TzId> tzId = dtStart.get().getParameter(Parameter.TZID);

--- a/src/test/groovy/net/fortuna/ical4j/model/VEventGetEndDateTest.groovy
+++ b/src/test/groovy/net/fortuna/ical4j/model/VEventGetEndDateTest.groovy
@@ -1,0 +1,68 @@
+/*
+ *  Copyright (c) 2022, Ben Fortuna
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   o Redistributions of source code must retain the above copyright
+ *  notice, this list of conditions and the following disclaimer.
+ *
+ *   o Redistributions in binary form must reproduce the above copyright
+ *  notice, this list of conditions and the following disclaimer in the
+ *  documentation and/or other materials provided with the distribution.
+ *
+ *   o Neither the name of Ben Fortuna nor the names of any other contributors
+ *  may be used to endorse or promote products derived from this software
+ *  without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ *  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ *  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ *  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ *  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+package net.fortuna.ical4j.model
+
+import net.fortuna.ical4j.AbstractBuilderTest
+import net.fortuna.ical4j.model.property.DtEnd
+
+// test to demonstrate https://github.com/ical4j/ical4j/issues/824
+// UnsupportedTemporalTypeException: Unsupported unit: Seconds
+
+class VEventGetEndDateTest extends AbstractBuilderTest {
+
+    def "infers end date for event without DTEND"() {
+        given: "a calendar with DTSTART VALUE=DATE and no DTEND"
+        def calendarString = '''BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//ABC Corporation//NONSGML My Product//EN
+METHOD:PUBLISH
+BEGIN:VEVENT
+DTSTART;VALUE=DATE:20251027
+DTSTAMP:20251027T163047Z
+SUMMARY:Event with DTSTART VALUE=DATE and without DTEND
+END:VEVENT
+END:VCALENDAR
+'''
+        when: "the input is parsed"
+        def calendar = builder.build(new StringReader(calendarString))
+        def vevents = calendar.getComponents(Component.VEVENT)
+
+        then: "the calendar contains exactly one event"
+        vevents.size() == 1
+
+        and: "the inferred end date is the following day"
+        def endDate = vevents[0].getEndDate(true).orElseThrow()
+        endDate == new DtEnd("20251028")
+    }
+}


### PR DESCRIPTION
fixes #824 

## Problem
VEvent.getEndDate(true) currently uses java.time.Duration for all-day events (DTSTART with VALUE=DATE), which causes:

UnsupportedTemporalTypeException: Unsupported unit: Seconds


## Solution
Use java.time.Period for day-based calculation:
```
if (dtStart.get().getParameter(Parameter.VALUE).equals(Optional.of(Value.DATE_TIME))) {
    vEventDuration = new Duration(java.time.Period.ZERO);
} else {
    vEventDuration = new Duration(java.time.Period.ofDays(1));
}
```

This ensures all-day events without DTEND are inferred correctly, consistent with RFC 5545 §3.6.1.

## Test
VEventGetEndDateTest now passes for events without DTEND.