### PR TITLE
fix incorrect start/end validation on VFREEBUSY

### DIFF
--- a/src/main/java/net/fortuna/ical4j/model/component/VFreeBusy.java
+++ b/src/main/java/net/fortuna/ical4j/model/component/VFreeBusy.java
@@ -489,7 +489,7 @@ public class VFreeBusy extends CalendarComponent implements Prototype<VFreeBusy>
         final Optional<DtStart<Temporal>> dtStart = getProperty(DTSTART);
         final Optional<DtEnd<Temporal>> dtEnd = getProperty(DTEND);
         if (dtStart.isPresent() && dtEnd.isPresent()
-                && TemporalAdapter.isBefore(dtStart.get().getDate(), dtEnd.get().getDate())) {
+                && TemporalAdapter.isAfter(dtStart.get().getDate(), dtEnd.get().getDate())) {
             result.getEntries().add(new ValidationEntry("Property [" + Property.DTEND
                     + "] must be later in time than [" + Property.DTSTART + "]", ValidationEntry.Severity.ERROR,
                     getName()));

--- a/src/test/groovy/net/fortuna/ical4j/model/TemporalAdapterTest.groovy
+++ b/src/test/groovy/net/fortuna/ical4j/model/TemporalAdapterTest.groovy
@@ -84,5 +84,7 @@ class TemporalAdapterTest extends Specification {
         where:
         t1  | t2    | isBefore
         Instant.now()   | LocalDate.now()   | false
+        ZonedDateTime.parse('2006-01-01T00:00:00Z') | ZonedDateTime.parse('2006-01-08T00:00:00Z') | true
+        ZonedDateTime.parse('2006-01-08T00:00:00Z') | ZonedDateTime.parse('2006-01-01T00:00:00Z') | false
     }
 }

--- a/src/test/java/net/fortuna/ical4j/data/CalendarBuilderTest.java
+++ b/src/test/java/net/fortuna/ical4j/data/CalendarBuilderTest.java
@@ -33,6 +33,7 @@ package net.fortuna.ical4j.data;
 
 import net.fortuna.ical4j.model.Calendar;
 import net.fortuna.ical4j.util.CompatibilityHints;
+import net.fortuna.ical4j.validate.ValidationEntry;
 import net.fortuna.ical4j.validate.ValidationException;
 import net.fortuna.ical4j.validate.ValidationResult;
 import org.junit.After;
@@ -103,7 +104,8 @@ public class CalendarBuilderTest {
     public void testBuildValid(final String filename) throws IOException, ParserException, ValidationException {
         final FileInputStream fin = new FileInputStream(filename);
         Calendar calendar = new CalendarBuilder().build(fin);
-        calendar.validate();
+        ValidationResult result = calendar.validate();
+        Assert.assertFalse(result.getEntries().stream().map(ValidationEntry::getMessage).collect(Collectors.joining(",")), result.hasErrors());
     }
 
     /**


### PR DESCRIPTION
Note: I did not re-enable `testBuildValid`, as several cases still fail, but `rfc5545-sec3.6.4.ics` now passes validation.