### PR TITLE
fix: only set the formatter field once the final formatter has been created

### DIFF
--- a/src/main/java/net/fortuna/ical4j/model/CalendarDateFormat.java
+++ b/src/main/java/net/fortuna/ical4j/model/CalendarDateFormat.java
@@ -276,10 +276,11 @@ public class CalendarDateFormat implements Serializable {
         if (formatter == null) {
             synchronized (pattern) {
                 if (formatter == null) {
-                    formatter = DateTimeFormatter.ofPattern(pattern);
+                    DateTimeFormatter f = DateTimeFormatter.ofPattern(pattern);
                     if (pattern.endsWith("'Z'")) {
-                        formatter = formatter.withZone(ZoneOffset.UTC);
+                        f = f.withZone(ZoneOffset.UTC);
                     }
+                    formatter = f;
                 }
             }
         }


### PR DESCRIPTION
Assigning the intermediate `DateTimeFormatter.ofPattern(pattern);` to the `formatter` field would cause other calls to immediately return the incomplete `formatter` because the check `formatter == null` is `false`

This can lead to errors like
```
Caused by: java.time.temporal.UnsupportedTemporalTypeException: Unsupported field: YearOfEra
	at java.base/java.time.Instant.getLong(Instant.java:603)
	at java.base/java.time.format.DateTimePrintContext.getValue(DateTimePrintContext.java:308)
	at java.base/java.time.format.DateTimeFormatterBuilder$NumberPrinterParser.format(DateTimeFormatterBuilder.java:2914)
	at java.base/java.time.format.DateTimeFormatterBuilder$CompositePrinterParser.format(DateTimeFormatterBuilder.java:2529)
	at java.base/java.time.format.DateTimeFormatter.formatTo(DateTimeFormatter.java:1905)
	at java.base/java.time.format.DateTimeFormatter.format(DateTimeFormatter.java:1879)
	at deployment.achilles.war//net.fortuna.ical4j.model.CalendarDateFormat.format(CalendarDateFormat.java:336)
	at deployment.achilles.war//net.fortuna.ical4j.model.TemporalAdapter.toString(TemporalAdapter.java:205)
	at deployment.achilles.war//net.fortuna.ical4j.model.TemporalAdapter.toString(TemporalAdapter.java:188)
	at deployment.achilles.war//net.fortuna.ical4j.model.TemporalAdapter.toString(TemporalAdapter.java:169)
	at deployment.achilles.war//net.fortuna.ical4j.model.TemporalAdapter.(TemporalAdapter.java:73)
	at deployment.achilles.war//net.fortuna.ical4j.model.property.DateProperty.setDate(DateProperty.java:172)
	at deployment.achilles.war//net.fortuna.ical4j.model.property.DtStamp.(DtStamp.java:125)
	at deployment.achilles.war//net.fortuna.ical4j.model.property.DtStamp.(DtStamp.java:95)
```