### PR TITLE
Don't throw and catch NP exception

### DIFF
--- a/src/main/java/net/fortuna/ical4j/util/Configurator.java
+++ b/src/main/java/net/fortuna/ical4j/util/Configurator.java
@@ -59,9 +59,13 @@ public final class Configurator {
 
         boolean isLoaded;
         try (var in = ResourceLoader.getResourceAsStream("ical4j.properties")) {
-            CONFIG.load(in);
-            isLoaded = true;
-        } catch (IOException | NullPointerException e) {
+            if (in == null) {
+                isLoaded = false;
+            } else {
+                CONFIG.load(in);
+                isLoaded = true;
+            }
+        } catch (IOException e) {
             // defer logging until properties are loaded to avoid potential
             // reference to uninitialized config
             isLoaded = false;


### PR DESCRIPTION
For debug purposes it is better not to throw and catch NP exceptions.
Otherwise this will trigger exception breakpoints.