### PR TITLE
Fix empty continuation line when property is exactly max length

### DIFF
--- a/src/main/java/net/fortuna/ical4j/data/FoldingWriter.java
+++ b/src/main/java/net/fortuna/ical4j/data/FoldingWriter.java
@@ -115,10 +115,15 @@ public class FoldingWriter extends FilterWriter {
             boolean isHighSurrogate = Character.isHighSurrogate(buffer[i]);
             boolean hasLowSurrogate = i < maxIndex && Character.isLowSurrogate(buffer[i + 1]);
 
+            // Don't fold before line endings - RFC 5545 says "excluding the line break"
+            // so a line of exactly foldLength chars + CRLF is valid.
+            boolean isLineEnding = buffer[i] == '\r' || buffer[i] == '\n';
+
             // If we are at the fold limit and have a surrogate pair, fold before writing
             // the complete pair.
-            // OR Normal folding when the limit is reached"
-            if (lineLength >= foldLength - 1 && isHighSurrogate && hasLowSurrogate || lineLength >= foldLength) {
+            // OR Normal folding when the limit is reached
+            // BUT skip folding if we're about to write a line ending
+            if (!isLineEnding && (lineLength >= foldLength - 1 && isHighSurrogate && hasLowSurrogate || lineLength >= foldLength)) {
                 super.write(FOLD_PATTERN, 0, FOLD_PATTERN.length);
                 lineLength = 1;
             }

--- a/src/test/java/net/fortuna/ical4j/data/FoldingWriterTest.java
+++ b/src/test/java/net/fortuna/ical4j/data/FoldingWriterTest.java
@@ -126,4 +126,37 @@ class FoldingWriterTest {
         }
     }
 
+    /**
+     * Test that a line of exactly foldLength chars followed by CRLF does NOT
+     * create an empty continuation line.
+     *
+     * RFC 5545 Section 3.1: "Lines of text SHOULD NOT be longer than 75 octets,
+     * excluding the line break." - the line break doesn't count, so a line of
+     * exactly 75 chars + CRLF is valid and should not be folded.
+     *
+     * @see <a href="https://github.com/ical4j/ical4j/issues/832">Issue #832</a>
+     */
+    @Test
+    void testNoFoldAtExactMaxLength() throws IOException {
+        StringWriter sw = new StringWriter();
+
+        // PRODID: (7 chars) + 68 chars = 75 chars exactly
+        String exactlyMaxLength = "PRODID:01234567890123456789012345678901234567890123456789012345678901234567";
+        assertEquals(75, exactlyMaxLength.length());
+
+        try (FoldingWriter writer = new FoldingWriter(sw, 75)) {
+            writer.write(exactlyMaxLength);
+            writer.write(Strings.LINE_SEPARATOR);
+            writer.write("VERSION:2.0");
+            writer.write(Strings.LINE_SEPARATOR);
+
+            // Should NOT have an empty continuation line after PRODID
+            assertEquals(exactlyMaxLength
+                    + Strings.LINE_SEPARATOR
+                    + "VERSION:2.0"
+                    + Strings.LINE_SEPARATOR,
+                    sw.getBuffer().toString());
+        }
+    }
+
 }


### PR DESCRIPTION
Fixes #832

## Problem

When a property line is exactly `foldLength` characters (e.g., 75) and followed by CRLF, the code folds before the line ending, creating an empty continuation line:

```
PRODID:...(75 chars)...\r\n
 \r\n
```

This is rejected by some servers like iCloud.

## Root Cause

RFC 5545 Section 3.1 states:
> Lines of text SHOULD NOT be longer than 75 octets, **excluding the line break**.

The line break doesn't count toward the 75 octet limit, so a line of exactly 75 chars + CRLF is valid and should not trigger folding.

## Fix

Skip folding when the next character to write is a line ending (`\r` or `\n`):

```java
boolean isLineEnding = buffer[i] == '\r' || buffer[i] == '\n';
if (!isLineEnding && (...existing conditions...)) {
    // fold
}
```

## Test

Added `testNoFoldAtExactMaxLength()` to verify that a 75-char line followed by CRLF produces no empty continuation.