### PR TITLE
Fix XXE vulnerability in HCalendarParser

### DIFF
--- a/src/main/java/net/fortuna/ical4j/data/HCalendarParser.java
+++ b/src/main/java/net/fortuna/ical4j/data/HCalendarParser.java
@@ -151,6 +151,12 @@ public class HCalendarParser implements CalendarParser {
     static {
         BUILDER_FACTORY.setNamespaceAware(true);
         BUILDER_FACTORY.setIgnoringComments(true);
+        try {
+            // Prevent XXE attacks - see https://github.com/ical4j/ical4j/issues/802
+            BUILDER_FACTORY.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        } catch (ParserConfigurationException e) {
+            throw new CalendarException(e);
+        }
 
         XPATH_METHOD = compileExpression("//*[contains(@class, 'method')]");
         XPATH_VEVENTS = compileExpression("//*[contains(@class, 'vevent')]");


### PR DESCRIPTION
## Summary

Enable `FEATURE_SECURE_PROCESSING` on `DocumentBuilderFactory` in `HCalendarParser` to prevent XML External Entity (XXE) injection attacks.

This is a minimal, targeted fix that adds secure processing to the existing static initialization block.

## Changes

- Added `BUILDER_FACTORY.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true)` in `HCalendarParser.java`

## Testing

- Verified the code compiles successfully
- No existing tests for HCalendarParser to regress

Fixes #802