### PR TITLE
Fixes #849: Out of memory and extremely long execution time with the "FREQ=SECONDLY;INTERVAL=1" rule and a seed in the past.

### DIFF
--- a/src/main/java/net/fortuna/ical4j/model/Recur.java
+++ b/src/main/java/net/fortuna/ical4j/model/Recur.java
@@ -1289,7 +1289,7 @@ public class Recur<T extends Temporal> implements Serializable {
         final Temporal periodEnd;
         final int maxCount;
 
-        final List<T> dates;
+        int generatedCount;
 
         T candidateSeed;
         int incrementMultiplier = 1;
@@ -1303,40 +1303,55 @@ public class Recur<T extends Temporal> implements Serializable {
         int noCandidateIncrementCount = 0;
 
         public DateSpliterator(T seed, Temporal periodStart, Temporal periodEnd, int maxCount) {
-            super(maxCount, 0);
+            super(maxCount>0 ? maxCount : Long.MAX_VALUE, ORDERED | DISTINCT | NONNULL);
             this.seed = seed;
             this.periodStart = periodStart;
             this.periodEnd = periodEnd;
             this.maxCount = maxCount;
 
-            dates = new ArrayList<>();
+            generatedCount = 0;
 
             candidateSeed = seed;
 
             // optimize the start time for selecting candidates
             // (only applicable where a COUNT is not specified)
             if (count == null) {
+                // Use and exponential approach to increment the candidate seed until it's after the period start.
                 T incremented = increment(seed, incrementMultiplier);
                 while (TemporalAdapter.isBefore(incremented, periodStart.minus(Math.max(getInterval(), 1), calIncField))) {
                     candidateSeed = incremented;
-                    incrementMultiplier++;
+                    incrementMultiplier *= 2;
                     if (candidateSeed == null) {
                         break;
                     }
                     incremented = increment(seed, incrementMultiplier);
                 }
+                // Now let's make a binary search between the last candidate seed and the current one to find the optimal candidate seed to start with.
+                int low = Math.max(1, incrementMultiplier / 2); // last before
+                int high = incrementMultiplier; // first after
+                while (low < high) {
+                    int mid = (low + high) / 2;
+                    incremented = increment(seed, mid);
+                    if (TemporalAdapter.isBefore(incremented, periodStart.minus(Math.max(getInterval(), 1), calIncField))) {
+                        candidateSeed  = incremented;
+                        low = mid + 1;
+                    } else {
+                        high = mid;
+                    }
+                }
+                incrementMultiplier = low;
             }
         }
 
         @Override
         public boolean tryAdvance(Consumer<? super T> action) {
-            boolean advance = maxCount < 0 || dates.size() < maxCount;
+            boolean advance = maxCount < 0 || generatedCount < maxCount;
             if (advance) {
                 if (getUntil() != null && lastCandidate != null && TemporalAdapter.isAfter(lastCandidate, getUntil())) {
                     advance = false;
                 } else if (periodEnd != null && lastCandidate != null && TemporalAdapter.isAfter(lastCandidate, periodEnd)) {
                     advance = false;
-                } else if (getCount() >= 1 && (dates.size() + invalidCandidates.size()) >= getCount()) {
+                } else if (getCount() >= 1 && (generatedCount + invalidCandidates.size()) >= getCount()) {
                     advance = false;
                 }
             }
@@ -1375,7 +1390,7 @@ public class Recur<T extends Temporal> implements Serializable {
                     } else if (!TemporalAdapter.isBefore(lastCandidate, periodStart) && !TemporalAdapter.isAfter(lastCandidate, periodEnd)
                             && (getUntil() == null || !TemporalAdapter.isAfter(lastCandidate, getUntil()))) {
 
-                        dates.add(lastCandidate);
+                        generatedCount++;
                         action.accept(lastCandidate);
                     }
                 }

--- a/src/test/groovy/net/fortuna/ical4j/model/RecurSpec.groovy
+++ b/src/test/groovy/net/fortuna/ical4j/model/RecurSpec.groovy
@@ -31,10 +31,10 @@
  */
 package net.fortuna.ical4j.model
 
-import net.fortuna.ical4j.model.Period
 import net.fortuna.ical4j.transform.recurrence.Frequency
 import net.fortuna.ical4j.util.CompatibilityHints
 import spock.lang.Specification
+import spock.lang.Timeout
 import spock.lang.Unroll
 
 import java.time.*
@@ -503,6 +503,20 @@ class RecurSpec extends Specification {
  20520318T163700, 20520318T163800, 20520325T163700, 20520325T163800, 20520401T163700, 20520401T163800,
  20520408T163700, 20520408T163800, 20520415T163700, 20520415T163800, 20520422T163700, 20520422T163800,
  20520429T163700, 20520429T163800, 20520506T163700, 20520506T163800, 20520513T163700, 20520513T163800''').dates
+    }
+
+    @Timeout(5)
+    def 'test getdates as string with seed far in the past'() {
+        given: 'a recurrence rule'
+        Recur<LocalDateTime> recur = new Recur.Builder<LocalDateTime>().frequency(Frequency.SECONDLY).interval(1).build()
+
+        when: 'dates are generated for a period'
+        def count = recur.getDatesAsStream((LocalDateTime) TemporalAdapter.parse('20200101T000000').temporal,
+                (LocalDateTime) TemporalAdapter.parse('20260101T000000').temporal,
+                (LocalDateTime) TemporalAdapter.parse('20260131T235959').temporal, -1).count()
+
+        then: 'result matches expected'
+        count == 86400 * 31 // number of seconds in January 2026
     }
 
     def 'test getdates across a DST-change'() {


### PR DESCRIPTION
A faster search of the first candidate was implemented. Initially, it searches by incrementally increasing the steps exponentially. It then performs a binary search.

Complexity reduced from O(n) to O(log(n)).

The "dates" list that was exhausting memory and was only used for counting generated dates, replaced with a lighter integer count field

All tests are passing