### PR TITLE
Change `MapTimeZoneCache` to not write `null` values to the cache

### DIFF
--- a/src/main/java/net/fortuna/ical4j/util/MapTimeZoneCache.java
+++ b/src/main/java/net/fortuna/ical4j/util/MapTimeZoneCache.java
@@ -32,7 +32,12 @@ public class MapTimeZoneCache implements TimeZoneCache {
     @Override
     public VTimeZone getTimezone(String id, Supplier<VTimeZone> putIfAbsent) {
         if (!containsId(id)) {
-            mapCache.put(id, putIfAbsent.get());
+            VTimeZone vTimeZone = putIfAbsent.get();
+            if (vTimeZone != null) {
+                mapCache.put(id, vTimeZone);
+            } else {
+                return null;
+            }
         }
         return getTimezone(id);
     }

--- a/src/test/java/net/fortuna/ical4j/model/TimeZoneTest2.java
+++ b/src/test/java/net/fortuna/ical4j/model/TimeZoneTest2.java
@@ -6,6 +6,7 @@ import org.junit.Test;
 import java.time.Instant;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 public class TimeZoneTest2 {
 
@@ -125,4 +126,12 @@ public class TimeZoneTest2 {
         assertEquals(1609945200000L, dt2.getTime());    // fails!
     }
 
+    @Test
+    public void getTimeZone_with_unknown_id() {
+        var tzReg = TimeZoneRegistryFactory.getInstance().createRegistry();
+
+        var timeZone = tzReg.getTimeZone("unknown");
+
+        assertNull(timeZone);
+    }
 }


### PR DESCRIPTION
Changes `MapTimeZoneCache` to not write `null` values to the cache. `CaffeineTimeZoneCache` already behaves this way.

Fixes #857