### PR TITLE
Fix `VEventTest.testEventEndDate()`

### DIFF
--- a/src/test/java/net/fortuna/ical4j/model/component/VEventTest.java
+++ b/src/test/java/net/fortuna/ical4j/model/component/VEventTest.java
@@ -423,7 +423,7 @@ public class VEventTest<T extends Temporal> extends CalendarComponentTest<T> {
         LocalDate startDate = LocalDate.now();
         log.info("Start date: " + startDate);
         VEvent event = new VEvent(startDate, java.time.Period.ofDays(3), "3 day event");
-        Temporal endDate = event.getDateTimeEnd().getDate();
+        Temporal endDate = event.getEndDate().orElseThrow().getDate();
         log.info("End date: " + endDate);
         assertEquals(startDate.plusDays(3), endDate);
     }
@@ -660,7 +660,7 @@ public class VEventTest<T extends Temporal> extends CalendarComponentTest<T> {
         suite.addTest(new VEventTest<>("testGetConsumedTime2"));
         suite.addTest(new VEventTest<>("testGetConsumedTime3"));
         suite.addTest(new VEventTest<>("testGetConsumedTimeByCount"));
-//        suite.addTest(new VEventTest<>("testEventEndDate")); // Failed after re-enabling JUnit 3/4 tests
+        suite.addTest(new VEventTest<>("testEventEndDate"));
         suite.addTest(new VEventTest<>("testGetConsumedTimeWithExDate"));
         suite.addTest(new VEventTest<>("testGetConsumedTimeWithExDate2"));
         suite.addTest(new VEventTest<>("testIsCalendarComponent", event));


### PR DESCRIPTION
The refactoring in 602da824f7b58c7a4fae1336e26e8c975285c77a accidentally changed `testEventEndDate()` to call a method that doesn't calculate the end date from DTSTART + DURATION.

Changing it back fixes the test.