### PR TITLE
Fix case-sensitivity of enumerations

### DIFF
--- a/src/main/java/net/fortuna/ical4j/model/LinkRelationType.java
+++ b/src/main/java/net/fortuna/ical4j/model/LinkRelationType.java
@@ -33,6 +33,8 @@
 
 package net.fortuna.ical4j.model;
 
+import net.fortuna.ical4j.util.Enums;
+
 /**
  * Registered Link Relation Types.
  * @see <a href="https://www.iana.org/assignments/link-relations/link-relations.xhtml">link-relations</a>
@@ -56,7 +58,7 @@ public enum LinkRelationType {
     via, webmention, working_copy, working_copy_of;
 
     public static LinkRelationType from(String linkRelationTypeString) {
-        return Enum.valueOf(LinkRelationType.class, linkRelationTypeString.replace("-", "_")
+        return Enums.parse(LinkRelationType.class, linkRelationTypeString.replace("-", "_")
                 .replace(".", "$"));
     }
 

--- a/src/main/java/net/fortuna/ical4j/model/LocationType.java
+++ b/src/main/java/net/fortuna/ical4j/model/LocationType.java
@@ -1,5 +1,7 @@
 package net.fortuna.ical4j.model;
 
+import net.fortuna.ical4j.util.Enums;
+
 /**
  * Location types as defined by the Location Types Registry (RFC4589): https://tools.ietf.org/html/rfc4589
  */
@@ -11,10 +13,10 @@ public enum LocationType {
     truck, underway, unknown, warehouse, water, watercraft;
 
     public static LocationType from(String locationTypeString) {
-        if ("public".equals(locationTypeString)) {
-            return Enum.valueOf(LocationType.class, "public_");
+        if ("public".equalsIgnoreCase(locationTypeString)) {
+            return Enums.parse(LocationType.class, "public_");
         } else {
-            return Enum.valueOf(LocationType.class, locationTypeString.replace("-", "_"));
+            return Enums.parse(LocationType.class, locationTypeString.replace("-", "_"));
         }
     }
 

--- a/src/main/java/net/fortuna/ical4j/model/Recur.java
+++ b/src/main/java/net/fortuna/ical4j/model/Recur.java
@@ -34,6 +34,7 @@ package net.fortuna.ical4j.model;
 import net.fortuna.ical4j.transform.recurrence.*;
 import net.fortuna.ical4j.util.CompatibilityHints;
 import net.fortuna.ical4j.util.Configurator;
+import net.fortuna.ical4j.util.Enums;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -352,11 +353,11 @@ public class Recur<T extends Temporal> implements Serializable {
         while (tokens.hasNext()) {
             final var token = tokens.next();
             if (FREQ.equalsIgnoreCase(token)) {
-                frequency = Frequency.valueOf(nextToken(tokens, token));
+                frequency = Enums.parse(Frequency.class, nextToken(tokens, token));
             } else if (SKIP.equalsIgnoreCase(token)) {
-                skip = Skip.valueOf(nextToken(tokens, token));
+                skip = Enums.parse(Skip.class, nextToken(tokens, token));
             } else if (RSCALE.equalsIgnoreCase(token)) {
-                rscale = RScale.valueOf(nextToken(tokens, token));
+                rscale = Enums.parse(RScale.class, nextToken(tokens, token));
                 chronology = Chronology.of(rscale.getChronology());
             } else if (UNTIL.equalsIgnoreCase(token)) {
                 final String untilString = nextToken(tokens, token);
@@ -384,7 +385,7 @@ public class Recur<T extends Temporal> implements Serializable {
             } else if (BYSETPOS.equalsIgnoreCase(token)) {
                 setPosList = new NumberList(nextToken(tokens, token), chronology.range(ChronoField.DAY_OF_YEAR), true);
             } else if (WKST.equalsIgnoreCase(token)) {
-                weekStartDay = WeekDay.getWeekDay(WeekDay.Day.valueOf(nextToken(tokens, token)));
+                weekStartDay = WeekDay.getWeekDay(Enums.parse(WeekDay.Day.class, nextToken(tokens, token)));
             } else {
                 if (experimentalTokensAllowed) {
                     // assume experimental value..
@@ -412,7 +413,7 @@ public class Recur<T extends Temporal> implements Serializable {
      */
     @Deprecated
     public Recur(final String frequency, final T until) {
-        this(Frequency.valueOf(frequency), until);
+        this(Enums.parse(Frequency.class, frequency), until);
     }
 
     public Recur(final Frequency frequency) {
@@ -436,7 +437,7 @@ public class Recur<T extends Temporal> implements Serializable {
      */
     @Deprecated
     public Recur(final String frequency, final int count) {
-        this(Frequency.valueOf(frequency), count);
+        this(Enums.parse(Frequency.class, frequency), count);
     }
 
     /**
@@ -1042,7 +1043,7 @@ public class Recur<T extends Temporal> implements Serializable {
      */
     @Deprecated
     public final void setFrequency(final String frequency) {
-        this.frequency = Frequency.valueOf(frequency);
+        this.frequency = Enums.parse(Frequency.class, frequency);
         validateFrequency();
     }
 

--- a/src/main/java/net/fortuna/ical4j/model/WeekDay.java
+++ b/src/main/java/net/fortuna/ical4j/model/WeekDay.java
@@ -31,6 +31,7 @@
  */
 package net.fortuna.ical4j.model;
 
+import net.fortuna.ical4j.util.Enums;
 import net.fortuna.ical4j.util.Numbers;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
@@ -103,7 +104,7 @@ public class WeekDay implements Serializable {
         } else {
             offset = 0;
         }
-        day = Day.valueOf(value.substring(value.length() - 2));
+        day = Enums.parse(Day.class, value.substring(value.length() - 2));
     }
     
     /**

--- a/src/main/java/net/fortuna/ical4j/model/parameter/Display.java
+++ b/src/main/java/net/fortuna/ical4j/model/parameter/Display.java
@@ -4,6 +4,7 @@ import net.fortuna.ical4j.model.Content;
 import net.fortuna.ical4j.model.Encodable;
 import net.fortuna.ical4j.model.Parameter;
 import net.fortuna.ical4j.model.ParameterFactory;
+import net.fortuna.ical4j.util.Enums;
 import net.fortuna.ical4j.util.RegEx;
 
 import java.util.Arrays;
@@ -73,7 +74,7 @@ public class Display extends Parameter implements Encodable {
         var valueStrings = value.split(RegEx.COMMA_DELIMITED);
         for (var valueString : valueStrings) {
             try {
-                Value.valueOf(valueString.toUpperCase());
+                Enums.parse(Value.class, valueString);
             } catch (IllegalArgumentException iae) {
                 if (!valueString.startsWith(Parameter.EXPERIMENTAL_PREFIX)) {
                     throw iae;

--- a/src/main/java/net/fortuna/ical4j/model/parameter/Feature.java
+++ b/src/main/java/net/fortuna/ical4j/model/parameter/Feature.java
@@ -4,6 +4,7 @@ import net.fortuna.ical4j.model.Content;
 import net.fortuna.ical4j.model.Encodable;
 import net.fortuna.ical4j.model.Parameter;
 import net.fortuna.ical4j.model.ParameterFactory;
+import net.fortuna.ical4j.util.Enums;
 import net.fortuna.ical4j.util.RegEx;
 
 import java.util.Arrays;
@@ -83,7 +84,7 @@ public class Feature extends Parameter implements Encodable {
         super(PARAMETER_NAME);
         for (var valueString : valueStrings) {
             try {
-                Value.valueOf(valueString.toUpperCase());
+                Enums.parse(Value.class, valueString);
             } catch (IllegalArgumentException iae) {
                 if (!valueString.startsWith(Parameter.EXPERIMENTAL_PREFIX)) {
                     throw iae;

--- a/src/main/java/net/fortuna/ical4j/model/parameter/LinkRel.java
+++ b/src/main/java/net/fortuna/ical4j/model/parameter/LinkRel.java
@@ -81,7 +81,7 @@ public class LinkRel extends Parameter {
     }
 
     public LinkRelationType getLinkRelationType() {
-        return LinkRelationType.valueOf(value);
+        return LinkRelationType.from(value);
     }
 
     public URI getUri() {

--- a/src/main/java/net/fortuna/ical4j/util/Configurator.java
+++ b/src/main/java/net/fortuna/ical4j/util/Configurator.java
@@ -114,7 +114,7 @@ public final class Configurator {
         Optional<String> property = getProperty(key);
         if (property.isPresent()) {
             try {
-                return Optional.of(Enum.valueOf(clazz, property.get()));
+                return Optional.of(Enums.parse(clazz, property.get()));
             } catch (IllegalArgumentException iae) {
                 LOG.error(String.format("Invalid configuration value: %s", key), iae);
                 return Optional.empty();

--- a/src/main/java/net/fortuna/ical4j/util/Enums.java
+++ b/src/main/java/net/fortuna/ical4j/util/Enums.java
@@ -1,0 +1,16 @@
+package net.fortuna.ical4j.util;
+
+public final class Enums {
+
+    private Enums() {
+    }
+
+    public static <T extends Enum<T>> T parse(Class<T> enumClass, String value) {
+        for (T constant : enumClass.getEnumConstants()) {
+            if (constant.name().equalsIgnoreCase(value)) {
+                return constant;
+            }
+        }
+        throw new IllegalArgumentException("No enum constant " + enumClass.getCanonicalName() + "." + value);
+    }
+}


### PR DESCRIPTION
According to RFC5545:

> All names of properties, property parameters, enumerated property values, and property parameter values are case-insensitive.

Add a utility class `Enums.java` to do the trick.