### PR TITLE
Use different `Scanner` constructor for Android compatibility

### DIFF
--- a/src/main/java/net/fortuna/ical4j/transform/compliance/TzHelper.java
+++ b/src/main/java/net/fortuna/ical4j/transform/compliance/TzHelper.java
@@ -84,7 +84,9 @@ public class TzHelper {
     }
 
     private static void initMsTimezones() {
-        try (var scanner = new Scanner(TzHelper.class.getResourceAsStream(MS_TIMEZONES_FILE), StandardCharsets.UTF_8)) {
+        // Note: Scanner(InputStream, Charset) is not available on Android versions prior to Android 14.
+        //noinspection CharsetObjectCanBeUsed
+        try (var scanner = new Scanner(TzHelper.class.getResourceAsStream(MS_TIMEZONES_FILE), "UTF-8")) {
             while (scanner.hasNext()) {
                 var arr = scanner.nextLine().split("=");
                 var standardTzId = arr[1];


### PR DESCRIPTION
The [`Scanner(InputStream, Charset)`](https://developer.android.com/reference/java/util/Scanner#Scanner(java.io.InputStream,%20java.nio.charset.Charset)) constructor was added in Android 14 (API level 34). Unfortunately, this constructor is currently not part of the [list of APIs](https://developer.android.com/studio/write/java8-support-table) that's "desugared" by Android's build tooling.

This PR changes the code to use a `Scanner` constructor that is available since Android's API level 1.