### PR TITLE
fix: apply DST transitions for non-recurring VTIMEZONE observances (#793)

### DIFF
--- a/src/main/java/net/fortuna/ical4j/model/ZoneRulesBuilder.java
+++ b/src/main/java/net/fortuna/ical4j/model/ZoneRulesBuilder.java
@@ -102,10 +102,19 @@ public class ZoneRulesBuilder {
                 if (periodEnd.isBefore(startDate)) {
                     periodEnd = startDate.plusYears(5);
                 }
-                observance.calculateRecurrenceSet(new Period<>(startDate, periodEnd)).forEach( p -> {
-                    transitions.add(ZoneOffsetTransition.of(LocalDateTime.from(p.getStart()),
+                var recurrenceSet = observance.calculateRecurrenceSet(new Period<>(startDate, periodEnd));
+                if (recurrenceSet.isEmpty()) {
+                    // A non-recurring observance (no RRULE/RDATE) defines a single transition at its
+                    // DTSTART, but calculateRecurrenceSet omits the zero-duration initial instance that
+                    // lies exactly on the period start boundary. Add it explicitly; otherwise the zone
+                    // collapses to a single fixed offset and DST is never applied (issue #793).
+                    transitions.add(ZoneOffsetTransition.of(startDate,
                             offsetFrom.get().getOffset(), offsetTo.getOffset()));
-                });
+                } else {
+                    recurrenceSet.forEach(p -> transitions.add(ZoneOffsetTransition.of(
+                            LocalDateTime.from(p.getStart()),
+                            offsetFrom.get().getOffset(), offsetTo.getOffset())));
+                }
             }
         }
         return transitions;

--- a/src/test/groovy/net/fortuna/ical4j/model/ZoneRulesBuilderTest.groovy
+++ b/src/test/groovy/net/fortuna/ical4j/model/ZoneRulesBuilderTest.groovy
@@ -81,6 +81,41 @@ class ZoneRulesBuilderTest extends Specification {
         'America/Los_Angeles'   | LocalDateTime.of(2023, 12, 14, 17, 0, 0, 0)   | ZoneOffset.ofHours(-8)
     }
 
+    def 'build DST transitions from non-recurring (single date-time) observances'() {
+        given: 'a VTIMEZONE whose DAYLIGHT/STANDARD observances are one-off transitions (no RRULE)'
+        // This is the form emitted by some clients (e.g. Apple/iCloud) - see issue #793.
+        def tzstring = '''\
+                BEGIN:VCALENDAR
+                VERSION:2.0
+                BEGIN:VTIMEZONE
+                TZID:America/New_York
+                X-LIC-LOCATION:America/New_York
+                BEGIN:DAYLIGHT
+                DTSTART;VALUE=DATE-TIME:20250309T070000
+                TZNAME:EDT
+                TZOFFSETFROM:-0500
+                TZOFFSETTO:-0400
+                END:DAYLIGHT
+                BEGIN:STANDARD
+                DTSTART;VALUE=DATE-TIME:20251102T060000
+                TZNAME:EST
+                TZOFFSETFROM:-0400
+                TZOFFSETTO:-0500
+                END:STANDARD
+                END:VTIMEZONE
+                END:VCALENDAR
+                '''.stripIndent()
+        def vtimezone = new CalendarBuilder().build(new StringReader(tzstring)).getComponent('VTIMEZONE').get()
+
+        when: 'zone rules are built from the VTIMEZONE'
+        def zonerules = new ZoneRulesBuilder().vTimeZone(vtimezone).build()
+
+        then: 'the one-off DST transitions are applied rather than collapsing to a single fixed offset'
+        // before the fix these observances produced no transitions, so summer incorrectly returned EST (-05:00)
+        zonerules.getOffset(LocalDateTime.of(2025, 2, 21, 14, 30)) == ZoneOffset.ofHours(-5)
+        zonerules.getOffset(LocalDateTime.of(2025, 7, 15, 14, 30)) == ZoneOffset.ofHours(-4)
+    }
+
     def 'test relaxed parsing of invalid tz definitions'() {
 
         given: 'relaxed parsing enabled'


### PR DESCRIPTION
## Summary

Fixes #793.

A `VTIMEZONE` whose `STANDARD`/`DAYLIGHT` observances are defined as **single, non-recurring transitions** (a one-off `DTSTART` with no `RRULE`/`RDATE`) produced `ZoneRules` with **no offset transitions at all**, so the zone collapsed to a single fixed offset and DST was never applied. This is a form emitted by several clients (e.g. Apple/iCloud), so events were resolved with the wrong offset whenever DST was in effect.

### Reproduction

```
BEGIN:VTIMEZONE
TZID:America/New_York
BEGIN:DAYLIGHT
DTSTART;VALUE=DATE-TIME:20250309T070000
TZOFFSETFROM:-0500
TZOFFSETTO:-0400
END:DAYLIGHT
BEGIN:STANDARD
DTSTART;VALUE=DATE-TIME:20251102T060000
TZOFFSETFROM:-0400
TZOFFSETTO:-0500
END:STANDARD
END:VTIMEZONE
```

Building `ZoneRules` from the above yields an empty transition list:

- `getOffset(2025-02-21T14:30)` → `-05:00` (correct, but only because the zone is permanently EST)
- `getOffset(2025-07-15T14:30)` → `-05:00` ❌ — should be `-04:00` (EDT)

(The original report observed `-04:00` year-round; intervening changes flipped the constant to `-05:00`, but in both cases the zone has **no** transitions, so summer is still wrong.)

## Root cause

`ZoneRulesBuilder.buildDSTTransitions()` enumerates each observance's transition instants via `Observance.calculateRecurrenceSet(new Period<>(startDate, periodEnd))`.

For a non-recurring observance, that recurrence set is built from the `DTSTART` alone, as a **zero-duration initial instance**. `RecurrenceSet` only adds that initial instance when `period.intersects(initialPeriod)` is true, but `Period.intersects()` requires a non-empty overlap (strict `<`), so a zero-duration instance lying exactly on the query period's **start** boundary is never matched. The query period starts at `startDate` (the observance's own `DTSTART`), so the single transition is always dropped and `buildDSTTransitions()` returns nothing.

Fixing this inside `RecurrenceSet`/`Period` was considered and rejected: making the boundary inclusive there changes period-range filtering semantics and breaks `PeriodRuleTest`, because range filtering intentionally treats a boundary-touching occurrence as outside the range.

## Fix

Handle the non-recurring case explicitly in `buildDSTTransitions()`: when the recurrence set comes back empty, add a single transition at the observance's `DTSTART`. This mirrors how the sibling `buildStandardOffsetTransitions()` already derives transitions directly from observance start dates, and is scoped entirely to timezone-rule construction. Recurring observances (`RRULE`/`RDATE`) keep the existing expansion path unchanged.

## Tests

- Added `ZoneRulesBuilderTest > "build DST transitions from non-recurring (single date-time) observances"`, which builds rules from the reproduction `VTIMEZONE` and asserts `getOffset` returns `-05:00` in winter and `-04:00` in summer.
- The change also fixes the previously-failing `Asia/Ust-Nera` definition in `TimeZoneUpdaterTest` (`test update all tz definitions`), which exercises the same non-recurring-observance path against the bundled zoneinfo data.
- Full suite: no new failures introduced by this change.
