### PR TITLE
fix: preserve UTC offset in Period.toInterval for OffsetDateTime

### DIFF
--- a/src/main/java/net/fortuna/ical4j/model/Period.java
+++ b/src/main/java/net/fortuna/ical4j/model/Period.java
@@ -38,6 +38,7 @@ import java.io.Serializable;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.Temporal;
@@ -479,6 +480,13 @@ public class Period<T extends Temporal> implements Comparable<Period<T>>, Serial
 //            throw new UnsupportedOperationException("Unable to create Interval from date-only temporal.");
         } else if (start instanceof Instant) {
             return Interval.of((Instant) start, (Instant) end);
+        } else if (start instanceof OffsetDateTime){
+			if(duration != null){
+				return Interval.of(((OffsetDateTime) start).toInstant(), duration.toDuration());
+			}else{
+				return Interval.of(((OffsetDateTime) start).toInstant(),
+						((OffsetDateTime) end).toInstant());
+			}
         } else {
             // calculate zone offset based on current applicable rules
             var zoneOffset = zoneId.getRules().getOffset(Instant.now());

--- a/src/test/java/net/fortuna/ical4j/model/PeriodTest.java
+++ b/src/test/java/net/fortuna/ical4j/model/PeriodTest.java
@@ -37,7 +37,9 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.time.OffsetDateTime;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.TimeZone;
 
@@ -94,4 +96,28 @@ public class PeriodTest {
 
         LOG.info("Timezone test - period: [" + p + "]");
     }
+	
+	/**
+	 * Regression test for VFREEBUSY.
+	 * When start/end are OffSetDateTime with UTC timeStamps, period.toInterval()
+	 * must not re-apply systems timezone.
+	 */
+	@Test
+	public void testUTCOffSetDateTimeNotShiftedBySystemTimezone() {
+		//Simulated system timezone
+		TimeZone.setDefault(TimeZone.getTimeZone("Asia/Bangkok"));
+		
+		//FREEBUSY:20250110T100000Z/20250110T103000Z
+		OffsetDateTime start = OffsetDateTime.of(2025, 1, 10, 10, 0, 0, 0, ZoneOffset.UTC);
+		OffsetDateTime end   = OffsetDateTime.of(2025, 1, 10, 10, 30, 0, 0, ZoneOffset.UTC);
+		
+		Period<OffsetDateTime> period = new Period<>(start, end);
+		
+		org.threeten.extra.Interval interval = period.toInterval(ZoneId.of("Asia/Bangkok"));
+		
+		assertEquals(start.toInstant(), interval.getStart(),
+				"Start instant must not be shifted by system timezone");
+		assertEquals(end.toInstant(), interval.getEnd(),
+				"End instant must not be shifted by system timezone");
+	}
 }


### PR DESCRIPTION
## Problem
Fixes #845

VFREEBUSY with UTC FREEBUSY periods is parsed with shifted time on 
systems with a non UTC default timezone (+07).

Period.toInterval(ZoneId) falls through to the `else` branch for 
OffsetDateTime, which strips the offset(Z) via 
LocalDateTime.from() and re-applies the system timezone instead.


## Root Cause
LocalDateTime.from(offsetDateTime) discards the UTC offset,
then the system timezone is applied, shifting the time.

## Fix
Added an explicit OffsetDateTime branch that calls .toInstant()
directly, preserving the original offset without any zone conversion.

## Test
Added test in PeriodTest simulating a +07 system 
timezone (matching the bug report environment).

Before: 10:00Z → 03:00Z 
After:  10:00Z → 10:00Z