### PR TITLE
fix: parse non-DST VTIMEZONE with BYMONTH-only RRULE (e.g. Apple Asia/Tokyo)

### DIFF
--- a/openspec/changes/archive/2026-06-02-fix-vtimezone-bymonth-only-zonerules/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-02-fix-vtimezone-bymonth-only-zonerules/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-02

--- a/openspec/changes/archive/2026-06-02-fix-vtimezone-bymonth-only-zonerules/design.md
+++ b/openspec/changes/archive/2026-06-02-fix-vtimezone-bymonth-only-zonerules/design.md
@@ -1,0 +1,87 @@
+## Context
+
+`ZoneRulesBuilder.build()` converts a `VTimeZone` into a JSR-310 `java.time.zone.ZoneRules`. Future DST transitions are built by `buildTransitionRules(List<Observance>, ZoneOffset)`, which translates each observance's `RRULE` into a `ZoneOffsetTransitionRule`.
+
+The current guard (`ZoneRulesBuilder.java:132`) only checks that the recur month list is non-empty, then unconditionally reads `getRecur().getDayList().get(0)` at line 134 and again at line 138:
+
+```java
+if (rrule.isPresent() && !rrule.get().getRecur().getMonthList().isEmpty()) {
+    var recurMonth = Month.of(rrule.get().getRecur().getMonthList().get(0).getMonthOfYear());
+    int dayOfMonth   = rrule.get().getRecur().getDayList().get(0).getOffset();   // line 134
+    if (dayOfMonth == 0) {
+        dayOfMonth   = rrule.get().getRecur().getMonthDayList().get(0);
+    }
+    var dayOfWeek    = WeekDay.getDayOfWeek(rrule.get().getRecur().getDayList().get(0)); // line 138
+    ...
+}
+```
+
+When the `RRULE` is `FREQ=YEARLY;BYMONTH=1` (no `BYDAY`, no `BYMONTHDAY`) the day list is empty, so `get(0)` throws `IndexOutOfBoundsException`. This propagates up through `TimeZoneRegistryImpl.register` → `DefaultContentHandler.endComponent` → `CalendarBuilder.build`, surfacing as a `ParserException` at the `END:VTIMEZONE` line. The offending shape is exactly what Apple Calendar emits for non-DST zones (e.g. `Asia/Tokyo`: single `STANDARD`, `TZOFFSETFROM == TZOFFSETTO`, yearly `BYMONTH`-only rule).
+
+`buildDSTTransitions` (line 89) already skips observances where from-offset equals to-offset; `buildTransitionRules` lacks that guard.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Parse calendars containing non-DST / fixed-date `VTIMEZONE` definitions that use a `BYMONTH`-only `RRULE`.
+- Produce a correct fixed-date transition rule when no weekday is specified, deriving the day from `DTSTART`.
+- Skip observances that describe no offset change, consistent with `buildDSTTransitions`.
+- Preserve existing behavior for `BYDAY`-based rules.
+
+**Non-Goals:**
+- No general RRULE-to-ZoneRules rewrite; only the missing-day-list and no-effect cases are addressed.
+- No change to historical transition handling (`buildStandardOffsetTransitions`, `buildDSTTransitions`) beyond what already exists.
+- No public API signature changes.
+
+## Decisions
+
+**Decision: Derive day-of-month from `DTSTART` with a null day-of-week when day list is empty (Option A).**
+
+`java.time.zone.ZoneOffsetTransitionRule.of(month, dayOfMonthIndicator, dayOfWeek, time, ...)` accepts a `null` `dayOfWeek`, which means "the transition is always on day-of-month `dayOfMonthIndicator`" — a fixed-date rule. This is the precise semantics of a `BYMONTH`-only yearly rule whose day is pinned by `DTSTART`. The revised branch:
+
+```java
+if (rrule.isPresent() && !rrule.get().getRecur().getMonthList().isEmpty()
+        && !offsetFrom.getOffset().equals(offsetTo.getOffset())) {        // no-effect guard
+    var recurMonth = Month.of(rrule.get().getRecur().getMonthList().get(0).getMonthOfYear());
+    var dayList    = rrule.get().getRecur().getDayList();
+    int dayOfMonth;
+    DayOfWeek dayOfWeek;
+    if (!dayList.isEmpty()) {
+        dayOfMonth = dayList.get(0).getOffset();
+        if (dayOfMonth == 0) {
+            dayOfMonth = rrule.get().getRecur().getMonthDayList().isEmpty()
+                ? startDate.getDate().getDayOfMonth()
+                : rrule.get().getRecur().getMonthDayList().get(0);
+        }
+        dayOfWeek = WeekDay.getDayOfWeek(dayList.get(0));
+    } else if (!rrule.get().getRecur().getMonthDayList().isEmpty()) {
+        dayOfMonth = rrule.get().getRecur().getMonthDayList().get(0);
+        dayOfWeek  = null;                                                // fixed date
+    } else {
+        dayOfMonth = startDate.getDate().getDayOfMonth();                 // derive from DTSTART
+        dayOfWeek  = null;                                                // fixed date
+    }
+    ...
+    transitionRules.add(ZoneOffsetTransitionRule.of(recurMonth, dayOfMonth, dayOfWeek, time, ...));
+}
+```
+
+*Alternative considered — Option B (only skip no-effect rules):* trivial, fixes the Apple `Asia/Tokyo` case because its from/to offsets are equal, but a `BYMONTH`-only rule with a *real* offset change would still crash. Rejected as incomplete; the no-effect guard is still adopted as a complementary safeguard.
+
+**Decision: Also adopt the no-effect guard (`!offsetFrom.equals(offsetTo)`).** Mirrors `buildDSTTransitions` and avoids emitting meaningless rules. For the Apple `Asia/Tokyo` case this alone short-circuits the branch, but the day-derivation logic is what makes the fix general.
+
+**Decision: `MONTHDAY` fallback when day list present but ordinal is 0.** Preserve the existing `dayOfMonth == 0 → monthDayList.get(0)` path, but guard it so an empty `monthDayList` falls back to the `DTSTART` day instead of throwing.
+
+## Risks / Trade-offs
+
+- [A `null` day-of-week changes the generated rule type for affected zones] → For previously-crashing inputs there is no prior behavior to regress; for inputs that reached `ZoneRules.of`, from-offset already equalled to-offset so the rule had no observable effect. Add a regression test asserting the Apple `Asia/Tokyo` calendar parses and resolves the event's zone.
+- [Day derived from `DTSTART` could differ from author intent if `DTSTART` is unusual] → `DTSTART` is the normative anchor of an observance per RFC 5545; deriving from it is the correct source of truth.
+- [Ordinal-weekday handling regressions] → Covered by the "existing BYDAY-based rules unchanged" requirement and a regression test on a standard DST zone (e.g. `BYMONTH=3;BYDAY=-1SU`).
+
+## Migration Plan
+
+Internal bug fix; no data migration. Rollback is reverting the `ZoneRulesBuilder` change. Previously-failing parses begin to succeed — no consumer needs to change.
+
+## Open Questions
+
+- None blocking. (If a `BYMONTH`-only rule ever pairs with a genuine offset change in the wild, the fixed-date rule from `DTSTART` is the intended result; no further handling anticipated.)

--- a/openspec/changes/archive/2026-06-02-fix-vtimezone-bymonth-only-zonerules/proposal.md
+++ b/openspec/changes/archive/2026-06-02-fix-vtimezone-bymonth-only-zonerules/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+`CalendarBuilder.build` throws `ParserException` (caused by `IndexOutOfBoundsException`) on a large class of real-world calendars: any embedded `VTIMEZONE` whose observance carries a `BYMONTH`-only `RRULE` with no `BYDAY` or `BYMONTHDAY`. This is exactly the shape Apple Calendar (macOS/iOS) emits for non-DST zones such as `Asia/Tokyo` — a single `STANDARD` observance with `TZOFFSETFROM == TZOFFSETTO` and `RRULE:FREQ=YEARLY;BYMONTH=1`. ical4j currently cannot ingest its own such timezones, so these calendars fail to parse entirely.
+
+## What Changes
+
+- `ZoneRulesBuilder.buildTransitionRules` derives the transition day-of-month from the observance `DTSTART` and uses a `null` day-of-week (a fixed-date transition rule) when the `RRULE` has neither `BYDAY` nor `BYMONTHDAY`, instead of unconditionally indexing `getDayList().get(0)`.
+- `buildTransitionRules` skips observances whose `TZOFFSETFROM` equals `TZOFFSETTO` (no-effect transitions), mirroring the existing guard in `buildDSTTransitions`.
+- As a result, non-DST and fixed-date `VTIMEZONE` definitions register successfully and the surrounding calendar parses.
+
+## Capabilities
+
+### New Capabilities
+- `vtimezone-zonerules`: Deriving a JSR-310 `java.time.zone.ZoneRules` instance from a `VTimeZone` component, including future transition rules built from observance `RRULE`s — distinct from generic property parsing.
+
+### Modified Capabilities
+<!-- None: no existing spec covers ZoneRules construction from VTIMEZONE. -->
+
+## Impact
+
+- Code: `net.fortuna.ical4j.model.ZoneRulesBuilder` (`buildTransitionRules`, and `build` which invokes it). Indirectly fixes `TimeZoneRegistryImpl.register` and `CalendarBuilder.build` for affected calendars.
+- APIs: No public API signature changes; behavior change is that previously-failing parses now succeed.
+- Dependencies: None.
+- Risk: Low — the crashing branch produced a transition rule that JSR-310 ignores when from-offset equals to-offset; behavior for valid DST rules with `BYDAY` is unchanged.

--- a/openspec/changes/archive/2026-06-02-fix-vtimezone-bymonth-only-zonerules/specs/vtimezone-zonerules/spec.md
+++ b/openspec/changes/archive/2026-06-02-fix-vtimezone-bymonth-only-zonerules/specs/vtimezone-zonerules/spec.md
@@ -1,0 +1,39 @@
+## ADDED Requirements
+
+### Requirement: Future transition rules from BYMONTH-only observance RRULEs
+
+When building `java.time.zone.ZoneRules` from a `VTimeZone`, the system SHALL build a future transition rule for an observance whose `RRULE` specifies a `BYMONTH` part even when the `RRULE` specifies neither a `BYDAY` part nor a `BYMONTHDAY` part. In that case the system SHALL derive the day-of-month from the observance `DTSTART` and produce a fixed-date transition rule (no day-of-week constraint).
+
+The system SHALL NOT throw `IndexOutOfBoundsException` (or otherwise fail registration) when an observance `RRULE` has a `BYMONTH` part but an empty day list.
+
+#### Scenario: Non-DST VTIMEZONE with yearly BYMONTH-only rule registers successfully
+
+- **WHEN** a calendar contains a `VTIMEZONE` with a single `STANDARD` observance whose `DTSTART` is `20000101T000000`, `TZOFFSETFROM:+0900`, `TZOFFSETTO:+0900`, and `RRULE:FREQ=YEARLY;BYMONTH=1` (e.g. Apple Calendar's `Asia/Tokyo`)
+- **THEN** `CalendarBuilder.build` parses the calendar without throwing
+- **AND** the timezone registers and produces a usable `ZoneRules` instance
+
+#### Scenario: BYMONTH-only rule derives day-of-month from DTSTART
+
+- **WHEN** an observance has an effective `RRULE` with `BYMONTH` set but no `BYDAY` and no `BYMONTHDAY`, and a `DTSTART` whose day-of-month is D
+- **THEN** the generated transition rule uses day-of-month D with no day-of-week constraint
+- **AND** the rule's month matches the `RRULE` `BYMONTH` value
+
+### Requirement: Skip no-effect transition rules
+
+When building future transition rules, the system SHALL ignore observances whose `TZOFFSETFROM` offset equals its `TZOFFSETTO` offset, since such an observance describes no actual offset change. This mirrors the existing behavior when building historical DST transitions.
+
+#### Scenario: Observance with equal from/to offsets produces no transition rule
+
+- **WHEN** an observance has `TZOFFSETFROM` equal to `TZOFFSETTO`
+- **THEN** no `ZoneOffsetTransitionRule` is generated for that observance
+- **AND** existing observances with differing offsets continue to generate transition rules unchanged
+
+### Requirement: Existing BYDAY-based transition rules unchanged
+
+The system SHALL continue to build transition rules for observances whose `RRULE` specifies a `BYDAY` part (e.g. `RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU`) exactly as before this change, including handling of ordinal weekday offsets and `BYMONTHDAY` fallback.
+
+#### Scenario: Standard DST rule with BYDAY still produces a weekday transition rule
+
+- **WHEN** an observance has `RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU` and differing from/to offsets
+- **THEN** the generated transition rule uses the last Sunday of March with the correct day-of-week constraint
+- **AND** the resulting `ZoneRules` matches the behavior prior to this change

--- a/openspec/changes/archive/2026-06-02-fix-vtimezone-bymonth-only-zonerules/tasks.md
+++ b/openspec/changes/archive/2026-06-02-fix-vtimezone-bymonth-only-zonerules/tasks.md
@@ -1,0 +1,19 @@
+## 1. Implement ZoneRulesBuilder fix
+
+- [x] 1.1 In `ZoneRulesBuilder.buildTransitionRules`, add the no-effect guard `!offsetFrom.getOffset().equals(offsetTo.getOffset())` to the rule-building condition (mirroring `buildDSTTransitions`)
+- [x] 1.2 Replace the unconditional `getDayList().get(0)` access with branching: when the day list is non-empty keep existing offset/`MONTHDAY` logic; when empty but `MONTHDAY` present, use `monthDayList.get(0)` with `null` day-of-week; otherwise derive `dayOfMonth` from `DTSTART` with `null` day-of-week
+- [x] 1.3 Guard the existing `dayOfMonth == 0` `MONTHDAY` fallback so an empty `monthDayList` falls back to the `DTSTART` day instead of throwing
+- [x] 1.4 Confirm `ZoneOffsetTransitionRule.of(...)` is called with the derived `dayOfMonth` and (possibly null) `dayOfWeek`, leaving month/time/offset arguments unchanged
+
+## 2. Tests
+
+- [x] 2.1 Add a regression test that parses the Apple `Asia/Tokyo` calendar (single STANDARD, `TZOFFSETFROM==TZOFFSETTO`, `RRULE:FREQ=YEARLY;BYMONTH=1`) and asserts no exception is thrown
+- [x] 2.2 Assert the registered `ZoneRules` is usable and the VEVENT `DTSTART;TZID=Asia/Tokyo` resolves to the expected offset (+09:00)
+- [x] 2.3 Add a unit test for `buildTransitionRules` (or via `ZoneRulesBuilder.build`) covering a `BYMONTH`-only observance: assert the transition rule uses the `DTSTART` day-of-month and a null day-of-week
+- [x] 2.4 Add a test asserting an observance with equal from/to offsets produces no transition rule
+- [x] 2.5 Add/confirm a test for a standard DST observance with `BYDAY` (e.g. `FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU`) to verify unchanged behavior
+
+## 3. Verify
+
+- [x] 3.1 Run the new tests plus the existing `ZoneRulesBuilder` / timezone test suite and confirm all pass
+- [x] 3.2 Confirm the original example calendar from the report parses end-to-end (calendar + VEVENT)

--- a/openspec/specs/vtimezone-zonerules/spec.md
+++ b/openspec/specs/vtimezone-zonerules/spec.md
@@ -1,0 +1,45 @@
+# VTIMEZONE zone rules
+
+## Purpose
+
+Defines the contract for `net.fortuna.ical4j.model.ZoneRulesBuilder` — deriving a `java.time.zone.ZoneRules` instance from a `net.fortuna.ical4j.model.component.VTimeZone`. Covers how observance `RRULE`s are translated into future `ZoneOffsetTransitionRule`s, including degenerate rules (e.g. non-DST zones emitted by Apple Calendar) that omit a weekday, and which observances are ignored.
+
+## Requirements
+
+### Requirement: Future transition rules from BYMONTH-only observance RRULEs
+
+When building `java.time.zone.ZoneRules` from a `VTimeZone`, the system SHALL build a future transition rule for an observance whose `RRULE` specifies a `BYMONTH` part even when the `RRULE` specifies neither a `BYDAY` part nor a `BYMONTHDAY` part. In that case the system SHALL derive the day-of-month from the observance `DTSTART` and produce a fixed-date transition rule (no day-of-week constraint).
+
+The system SHALL NOT throw `IndexOutOfBoundsException` (or otherwise fail registration) when an observance `RRULE` has a `BYMONTH` part but an empty day list.
+
+#### Scenario: Non-DST VTIMEZONE with yearly BYMONTH-only rule registers successfully
+
+- **WHEN** a calendar contains a `VTIMEZONE` with a single `STANDARD` observance whose `DTSTART` is `20000101T000000`, `TZOFFSETFROM:+0900`, `TZOFFSETTO:+0900`, and `RRULE:FREQ=YEARLY;BYMONTH=1` (e.g. Apple Calendar's `Asia/Tokyo`)
+- **THEN** `CalendarBuilder.build` parses the calendar without throwing
+- **AND** the timezone registers and produces a usable `ZoneRules` instance
+
+#### Scenario: BYMONTH-only rule derives day-of-month from DTSTART
+
+- **WHEN** an observance has an effective `RRULE` with `BYMONTH` set but no `BYDAY` and no `BYMONTHDAY`, and a `DTSTART` whose day-of-month is D
+- **THEN** the generated transition rule uses day-of-month D with no day-of-week constraint
+- **AND** the rule's month matches the `RRULE` `BYMONTH` value
+
+### Requirement: Skip no-effect transition rules
+
+When building future transition rules, the system SHALL ignore observances whose `TZOFFSETFROM` offset equals its `TZOFFSETTO` offset, since such an observance describes no actual offset change. This mirrors the existing behavior when building historical DST transitions.
+
+#### Scenario: Observance with equal from/to offsets produces no transition rule
+
+- **WHEN** an observance has `TZOFFSETFROM` equal to `TZOFFSETTO`
+- **THEN** no `ZoneOffsetTransitionRule` is generated for that observance
+- **AND** existing observances with differing offsets continue to generate transition rules unchanged
+
+### Requirement: Existing BYDAY-based transition rules unchanged
+
+The system SHALL continue to build transition rules for observances whose `RRULE` specifies a `BYDAY` part (e.g. `RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU`) exactly as before this change, including handling of ordinal weekday offsets and `BYMONTHDAY` fallback.
+
+#### Scenario: Standard DST rule with BYDAY still produces a weekday transition rule
+
+- **WHEN** an observance has `RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU` and differing from/to offsets
+- **THEN** the generated transition rule uses the last Sunday of March with the correct day-of-week constraint
+- **AND** the resulting `ZoneRules` matches the behavior prior to this change

--- a/src/main/java/net/fortuna/ical4j/model/ZoneRulesBuilder.java
+++ b/src/main/java/net/fortuna/ical4j/model/ZoneRulesBuilder.java
@@ -157,14 +157,33 @@ public class ZoneRulesBuilder {
             TzOffsetTo offsetTo = observance.getRequiredProperty(Property.TZOFFSETTO);
             DtStart<LocalDateTime> startDate = observance.getRequiredProperty(Property.DTSTART);
 
-            // ignore invalid rules
-            if (rrule.isPresent() && !rrule.get().getRecur().getMonthList().isEmpty()) {
-                var recurMonth = java.time.Month.of(rrule.get().getRecur().getMonthList().get(0).getMonthOfYear());
-                int dayOfMonth = rrule.get().getRecur().getDayList().get(0).getOffset();
-                if (dayOfMonth == 0) {
-                    dayOfMonth = rrule.get().getRecur().getMonthDayList().get(0);
+            // ignore invalid rules and no-effect transitions (mirrors buildDSTTransitions)
+            if (rrule.isPresent() && !rrule.get().getRecur().getMonthList().isEmpty()
+                    && !offsetFrom.getOffset().equals(offsetTo.getOffset())) {
+                var recur = rrule.get().getRecur();
+                var recurMonth = java.time.Month.of(recur.getMonthList().get(0).getMonthOfYear());
+
+                // derive the transition day. A BYDAY part may carry an ordinal offset (e.g. -1SU) or
+                // a plain weekday (offset 0, in which case BYMONTHDAY pins the day). When neither BYDAY
+                // nor BYMONTHDAY is present (e.g. FREQ=YEARLY;BYMONTH=1), fall back to the DTSTART day
+                // as a fixed-date transition (null day-of-week).
+                int dayOfMonth;
+                java.time.DayOfWeek dayOfWeek;
+                if (!recur.getDayList().isEmpty()) {
+                    dayOfMonth = recur.getDayList().get(0).getOffset();
+                    if (dayOfMonth == 0) {
+                        dayOfMonth = recur.getMonthDayList().isEmpty()
+                                ? startDate.getDate().getDayOfMonth() : recur.getMonthDayList().get(0);
+                    }
+                    dayOfWeek = WeekDay.getDayOfWeek(recur.getDayList().get(0));
+                } else if (!recur.getMonthDayList().isEmpty()) {
+                    dayOfMonth = recur.getMonthDayList().get(0);
+                    dayOfWeek = null;
+                } else {
+                    dayOfMonth = startDate.getDate().getDayOfMonth();
+                    dayOfWeek = null;
                 }
-                var dayOfWeek = WeekDay.getDayOfWeek(rrule.get().getRecur().getDayList().get(0));
+
                 var time = LocalTime.from(startDate.getDate());
                 boolean endOfDay = false;
                 var timeDefinition = TimeDefinition.WALL;

--- a/src/test/groovy/net/fortuna/ical4j/model/ZoneRulesBuilderTest.groovy
+++ b/src/test/groovy/net/fortuna/ical4j/model/ZoneRulesBuilderTest.groovy
@@ -116,6 +116,84 @@ class ZoneRulesBuilderTest extends Specification {
         zonerules.getOffset(LocalDateTime.of(2025, 7, 15, 14, 30)) == ZoneOffset.ofHours(-4)
     }
 
+    def 'parse non-DST VTIMEZONE with BYMONTH-only rule (Apple Asia/Tokyo)'() {
+        given: 'a calendar with an Apple-style non-DST Asia/Tokyo VTIMEZONE and an event'
+        def cal = '''BEGIN:VCALENDAR
+VERSION:2.0
+CALSCALE:GREGORIAN
+BEGIN:VTIMEZONE
+TZID:Asia/Tokyo
+BEGIN:STANDARD
+DTSTART:20000101T000000
+RRULE:FREQ=YEARLY;BYMONTH=1
+TZNAME:JST
+TZOFFSETFROM:+0900
+TZOFFSETTO:+0900
+END:STANDARD
+END:VTIMEZONE
+BEGIN:VEVENT
+UID:325B6458-1654-4318-9050-F0BEF24518B6
+DTSTART;TZID=Asia/Tokyo;VALUE=DATE-TIME:20260413T130000
+DTEND;TZID=Asia/Tokyo;VALUE=DATE-TIME:20260413T133000
+DTSTAMP;VALUE=DATE-TIME:20260530T140853Z
+RRULE:FREQ=WEEKLY;INTERVAL=1;WKST=MO;BYDAY=MO;UNTIL=20990331T040000Z
+END:VEVENT
+END:VCALENDAR'''
+
+        when: 'the calendar is parsed'
+        def calendar = new CalendarBuilder().build(new StringReader(cal))
+
+        then: 'no exception is thrown'
+        noExceptionThrown()
+
+        when: 'zone rules are built from the embedded VTIMEZONE'
+        def vtimezone = calendar.getComponent('VTIMEZONE').get()
+        def zonerules = new ZoneRulesBuilder().vTimeZone(vtimezone).build()
+
+        then: 'the zone resolves to a fixed +09:00 offset'
+        zonerules.getOffset(LocalDateTime.of(2026, 4, 13, 13, 0)) == ZoneOffset.ofHours(9)
+
+        and: 'no transition rule is generated for the no-effect (from == to) observance'
+        zonerules.getTransitionRules().isEmpty()
+    }
+
+    def 'BYMONTH-only observance yields a fixed-date transition rule derived from DTSTART'() {
+        given: 'an alternating zone whose STANDARD return uses a BYMONTH-only (fixed-date) rule'
+        def cal = '''BEGIN:VCALENDAR
+BEGIN:VTIMEZONE
+TZID:Test/FixedReturn
+BEGIN:DAYLIGHT
+DTSTART:20000326T020000
+RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU
+TZOFFSETFROM:+0100
+TZOFFSETTO:+0200
+END:DAYLIGHT
+BEGIN:STANDARD
+DTSTART:20001015T030000
+RRULE:FREQ=YEARLY;BYMONTH=10
+TZOFFSETFROM:+0200
+TZOFFSETTO:+0100
+END:STANDARD
+END:VTIMEZONE
+END:VCALENDAR'''
+
+        when: 'zone rules are built'
+        def calendar = new CalendarBuilder().build(new StringReader(cal))
+        def zonerules = new ZoneRulesBuilder().vTimeZone(calendar.getComponent('VTIMEZONE').get()).build()
+        def rules = zonerules.getTransitionRules()
+
+        then: 'the October (BYMONTH-only) rule uses the DTSTART day-of-month with no weekday constraint'
+        def october = rules.find { it.month == java.time.Month.OCTOBER }
+        october != null
+        october.dayOfMonthIndicator == 15
+        october.dayOfWeek == null
+
+        and: 'the March rule (BYDAY=-1SU) is unchanged and keeps its weekday constraint'
+        def march = rules.find { it.month == java.time.Month.MARCH }
+        march != null
+        march.dayOfWeek == DayOfWeek.SUNDAY
+    }
+
     def 'test relaxed parsing of invalid tz definitions'() {
 
         given: 'relaxed parsing enabled'


### PR DESCRIPTION
## Why

`CalendarBuilder.build` throws `ParserException` (caused by `IndexOutOfBoundsException`) on any embedded `VTIMEZONE` whose observance carries a `BYMONTH`-only `RRULE` with no `BYDAY`/`BYMONTHDAY`. This is exactly the shape Apple Calendar (macOS/iOS) emits for non-DST zones such as `Asia/Tokyo`:

```
BEGIN:STANDARD
DTSTART:20000101T000000
RRULE:FREQ=YEARLY;BYMONTH=1
TZOFFSETFROM:+0900
TZOFFSETTO:+0900
END:STANDARD
```

`ZoneRulesBuilder.buildTransitionRules` only checked that the month list was non-empty, then unconditionally read `getDayList().get(0)` — empty day list ⇒ crash at `END:VTIMEZONE`, failing the whole parse.

## What changed

- Derive the transition day-of-month from `DTSTART` with a `null` day-of-week (a fixed-date `ZoneOffsetTransitionRule`) when the `RRULE` has neither `BYDAY` nor `BYMONTHDAY`.
- Skip no-effect observances where `TZOFFSETFROM` equals `TZOFFSETTO`, mirroring the existing guard in `buildDSTTransitions`.
- Existing `BYDAY`-based rules (e.g. `BYMONTH=3;BYDAY=-1SU`) are unchanged.

## Tests

- Parses the Apple `Asia/Tokyo` calendar end-to-end (no exception, resolves to +09:00, no spurious transition rule).
- Verifies a `BYMONTH`-only observance yields a fixed-date rule using the `DTSTART` day with null day-of-week, while a sibling `BYDAY=-1SU` rule keeps its weekday constraint.
- Full suite passes, including the jacoco coverage gate.

Adds the `vtimezone-zonerules` capability spec (OpenSpec).

🤖 Generated with [Claude Code](https://claude.com/claude-code)