### PR TITLE
chore: patch build-tooling dependencies flagged by Dependabot

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,18 @@
+buildscript {
+    // The axion-release plugin (at its latest, 1.21.1) pulls Bouncy Castle 1.81/1.82 onto the
+    // plugin classpath, below the 1.84 that fixes GHSA-p93r-85wp-75v3, -cj8j-37rh-8475,
+    // -c3fc-8qff-9hwx and -wg6q-6289-32hp. Force the patched version until axion-release ships it.
+    // Build-time only; not part of the published ical4j artifact.
+    configurations.classpath {
+        resolutionStrategy {
+            force 'org.bouncycastle:bcprov-jdk18on:1.84',
+                    'org.bouncycastle:bcpg-jdk18on:1.84',
+                    'org.bouncycastle:bcpkix-jdk18on:1.84',
+                    'org.bouncycastle:bcutil-jdk18on:1.84'
+        }
+    }
+}
+
 plugins {
     id 'java-library'
     id 'groovy'
@@ -6,7 +21,7 @@ plugins {
     id 'signing'
 //    id 'org.hidetake.ssh' version '2.11.2' // errors when using Gradle 8.* with JDK 8
     id "pl.allegro.tech.build.axion-release" version "1.21.1" // errors when using Gradle 8.* with JDK 8 (https://github.com/allegro/axion-release-plugin/issues?q=is%3Aissue+is%3Aopen+%22Gradle+8%22+in%3Atitle)
-    id "com.palantir.revapi" version "1.7.0"
+    id "com.palantir.revapi" version "2.0.0"
 //    id "net.ltgt.errorprone" version "2.0.2" apply false
     id "biz.aQute.bnd.builder" version "$bndVersion"
 }
@@ -43,6 +58,15 @@ java {
 dependencies {
 //    errorprone "com.google.errorprone:error_prone_core:2.3.3"
 //    errorproneJavac "com.google.errorprone:javac:9+181-r4173-1"
+
+    // testcontainers (test-only) pulls commons-compress 1.24.0, below the 1.26.0 that fixes
+    // GHSA-4g9r-vxhx-9pgx and GHSA-4265-ccf5-phj5. Constrain to the patched version. Test scope
+    // only; not part of the published ical4j artifact.
+    constraints {
+        testImplementation('org.apache.commons:commons-compress:1.26.0') {
+            because 'CVE fixes; pulled transitively by testcontainers'
+        }
+    }
 
     api libs.slf4j, libs.commons.codec, libs.commons.lang, libs.threeten.extra
 


### PR DESCRIPTION
## Context

All 19 open Dependabot alerts are attributed to `settings.gradle`, which is Dependabot's catch-all for the **Gradle plugin/build classpath**. I traced every package — none are in ical4j's published `runtimeClasspath` (`slf4j`, `commons-codec`, `commons-lang3`, `commons-collections4`, `threeten-extra`). They run only at build time (release signing, API-diff checks) or in test scope, so **library consumers are unaffected**. This PR patches them anyway to clear the alerts.

## Changes

| Change | Clears |
|---|---|
| `com.palantir.revapi` 1.7.0 → **2.0.0** (pulls jackson-core/databind 2.21.1, snakeyaml 2.5, guava 33.6.0-jre) | 13 alerts: jackson (#11, #15, #31, #35), snakeyaml (#6–#10, #13, #14), guava (#17, #18) |
| Force **Bouncy Castle 1.84** on the plugin classpath | 4 alerts: #39–#42 |
| Constrain test-only **commons-compress 1.26.0** | 2 alerts: #21, #22 |

### Why a force for Bouncy Castle

`axion-release` is already at its latest release (1.21.1) and still resolves BC 1.81/1.82 — below the 1.84 that fixes the four advisories. A `buildscript` `resolutionStrategy.force` is the only way to patch it until axion-release ships 1.84. It's a patch-level bump within the same major, build-time only.

## Verification

- `./gradlew clean compileJava revapi` — clean (confirms the revapi 2.0.0 major bump applies and analyzes correctly).
- `buildEnvironment` / `dependencies` confirm all flagged packages now resolve to patched versions.
- ⚠️ `./gradlew test` has **2 pre-existing failures** (`ZoneRulesBuilderTest` Asia/Tokyo rows returning +10:00 vs expected +09:00). These are runtime offset-math failures unrelated to build tooling — they also fail on `develop` with this PR reverted. Out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)