### PR TITLE
fix: make ZoneRules derivation independent of the JVM default time zone

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,6 +88,10 @@ test {
 
 //    jvmArgs = [ "-Duser.timezone=UTC" ] // Some tests require default timezone to be UTC
 
+    // ZoneRulesTimezoneIndependenceTest only has signal when the JVM starts in a non-UTC zone;
+    // it is executed by the dedicated timezoneIndependenceTest task instead.
+    exclude '**/ZoneRulesTimezoneIndependenceTest*'
+
     // Make testcontainers usable on Podman without per-developer setup.
     // Testcontainers reads its config from env vars (Java system properties are
     // ignored for DOCKER_HOST and ryuk.disabled), so configure it here.
@@ -108,6 +112,21 @@ test {
         environment 'TESTCONTAINERS_RYUK_DISABLED', 'true'
     }
 }
+
+// Runs the timezone-independence guard with a non-UTC JVM default zone. ZoneRules derivation must
+// not depend on TimeZones.getDefault(); this catches regressions that pass under UTC-default CI.
+tasks.register('timezoneIndependenceTest', Test) {
+    description = 'Runs ZoneRules timezone-independence guards under a non-UTC default zone.'
+    group = 'verification'
+    testClassesDirs = sourceSets.test.output.classesDirs
+    classpath = sourceSets.test.runtimeClasspath
+    useJUnitPlatform()
+    systemProperty 'user.timezone', 'Australia/Sydney'
+    filter {
+        includeTestsMatching 'net.fortuna.ical4j.model.ZoneRulesTimezoneIndependenceTest'
+    }
+}
+check.dependsOn 'timezoneIndependenceTest'
 
 def resolvePodmanSocket() {
     try {

--- a/openspec/changes/archive/2026-06-02-fix-zonerules-default-timezone-dependence/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-02-fix-zonerules-default-timezone-dependence/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-02

--- a/openspec/changes/archive/2026-06-02-fix-zonerules-default-timezone-dependence/design.md
+++ b/openspec/changes/archive/2026-06-02-fix-zonerules-default-timezone-dependence/design.md
@@ -1,0 +1,66 @@
+## Context
+
+`ZoneRulesBuilder.build()` derives `java.time.zone.ZoneRules` from a `VTimeZone`. Historical DST changes are produced by `buildDSTTransitions(List<Observance>)`:
+
+```java
+LocalDateTime startDate = (LocalDateTime) start.getDate();
+LocalDateTime periodEnd = LocalDateTime.now();
+...
+observance.calculateRecurrenceSet(new Period<>(startDate, periodEnd)).forEach(p ->
+    transitions.add(ZoneOffsetTransition.of(LocalDateTime.from(p.getStart()),
+        offsetFrom.get().getOffset(), offsetTo.getOffset())));
+```
+
+The seed (`startDate`/`periodEnd`) is a **floating `LocalDateTime`**. `Observance.calculateRecurrenceSet` feeds it to `Recur.getDates`, which filters candidates against the RRULE `UNTIL` at `Recur.java:750` / `Recur.java:772` via `TemporalAdapter.isAfter(candidate, getUntil())`. When the candidate is a floating `LocalDateTime` and `UNTIL` is a UTC `Instant` (the `...Z` form mandated for VTIMEZONE), `TemporalComparator` resolves the floating value using `defaultZoneId = TimeZones.getDefault().toZoneId()` (`TemporalComparator.java:24-27`) — the **JVM default zone**.
+
+For `Asia/Tokyo` the bundled definition encodes expired 1948–1951 DST:
+
+```
+DAYLIGHT DTSTART:19500507T000000 (offsetFrom +0900) RRULE ... UNTIL=19510505T150000Z
+STANDARD DTSTART:19480912T010000 (offsetFrom +1000) RRULE ... UNTIL=19510908T150000Z
+```
+
+The final DAYLIGHT candidate `1951-05-06T00:00`:
+- default `UTC` → `1951-05-06T00:00Z` > `UNTIL` → excluded.
+- default `+10` → `1951-05-05T14:00Z` < `UNTIL` → included.
+
+The closing STANDARD (Sep 1951) is dropped in both cases, so in non-UTC zones the kept 1951 DAYLIGHT start has no matching end and the zone is stuck at +10:00 forever.
+
+`Observance.getLatestOnset` (`Observance.java:199-205`) already avoids this: it seeds `Recur.getDates` with an offset-aware `initialOnset` built at `offsetFrom`, so candidates are `OffsetDateTime` and the `UNTIL` comparison is deterministic. `buildDSTTransitions` is the outlier.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Make derived `ZoneRules` deterministic across JVM default time zones.
+- Fix `Asia/Tokyo` (and any zone with UTC-`UNTIL`-bounded historical DST) resolving to a wrong offset off-UTC.
+- Add a regression test that runs under a non-UTC default zone.
+
+**Non-Goals:**
+- No change to `TemporalComparator` / `Recur` `UNTIL` semantics generally; the fix is localized to how the VTIMEZONE recurrence seed is constructed.
+- No attempt to faithfully reproduce every historical DST instance (e.g. the 1951 Tokyo season). The contract is determinism and a correct present-day offset, not perfect historical fidelity — the pre-existing UTC behavior already omits 1951.
+- No change to future transition rules (`buildTransitionRules`).
+
+## Decisions
+
+**Decision: Seed `calculateRecurrenceSet` with offset-aware temporals at `TZOFFSETFROM`.**
+
+In `buildDSTTransitions`, build the period from `startDate.atOffset(offsetFrom)` and `periodEnd.atOffset(offsetFrom)` so the recurrence candidates are `OffsetDateTime`. The `UNTIL` comparison then resolves against the observance offset, independent of the JVM default zone. The downstream `LocalDateTime.from(p.getStart())` recovers the same wall-clock onset as before (applying then extracting `offsetFrom` is lossless for the local part), so transition local times are unchanged.
+
+Validated against the live `Asia/Tokyo` data: the AU default-zone recurrence count for the DAYLIGHT observance collapses from 2 → 1, matching the UTC result of 1 in every zone — deterministic, balanced transitions, +09:00 present-day.
+
+*Alternative considered — change `Observance.calculateRecurrenceSet` to always apply the observance offset:* more general, but `calculateRecurrenceSet` is a shared generic `Component` method used by `VEVENT`/`VTODO` etc.; broadening it risks unrelated recurrence behavior. The targeted seed change keeps blast radius to timezone derivation, where `offsetFrom` is the correct and available anchor.
+
+*Alternative considered — skip all expired-`UNTIL` observances entirely:* would also yield +09:00 for Tokyo, but discards legitimate historical transitions for other zones and doesn't address the underlying non-determinism. Rejected.
+
+## Risks / Trade-offs
+
+- [Other zones' historical transitions shift slightly] → The seed change only affects boundary instances at the `UNTIL` edge; non-boundary occurrences are unaffected. Existing `ZoneRulesBuilderTest` rows (Melbourne, LA, London, Sao Paulo, Sydney, etc.) guard against regressions and must continue to pass under the new test's forced zone too.
+- [Determinism test must force a non-UTC zone] → Set the default zone within the test and restore it in cleanup so other tests are unaffected; assert `Asia/Tokyo` resolves to +09:00 under that zone.
+
+## Migration Plan
+
+Internal bug fix; no data or API migration. Rollback is reverting the one-method change. Consumers in non-UTC zones simply begin getting correct offsets.
+
+## Open Questions
+
+- None blocking.

--- a/openspec/changes/archive/2026-06-02-fix-zonerules-default-timezone-dependence/proposal.md
+++ b/openspec/changes/archive/2026-06-02-fix-zonerules-default-timezone-dependence/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+`ZoneRulesBuilder` produces **different `ZoneRules` depending on the JVM default time zone**, so the same calendar resolves to different offsets on different machines. `Asia/Tokyo` resolves to +09:00 when the default zone is UTC (e.g. GitHub Actions CI) but +10:00 when it is east of UTC (e.g. `Australia/*`). This makes `ZoneRulesBuilderTest`'s `Asia/Tokyo` expectations pass on CI and fail locally, and — worse — means consumers in non-UTC zones get incorrect offsets.
+
+Root cause: `buildDSTTransitions` computes an observance's recurrence set from a *floating* `LocalDateTime` seed. When `Recur` compares a floating recurrence candidate against an RRULE `UNTIL` expressed in UTC, `TemporalComparator` resolves the floating value using `TimeZones.getDefault()` (the JVM default zone). For `Asia/Tokyo`'s 1948–1951 historical DST, this drops or keeps the 1951 boundary transitions inconsistently: in non-UTC zones a 1951 DAYLIGHT start is kept while the closing 1951 STANDARD is dropped, leaving the zone permanently in DST (+10:00).
+
+## What Changes
+
+- `ZoneRulesBuilder.buildDSTTransitions` seeds `Observance.calculateRecurrenceSet` with **offset-aware** temporals at the observance `TZOFFSETFROM` offset, instead of a floating `LocalDateTime`. This mirrors what `Observance.getLatestOnset` already does, making the `UNTIL` comparison resolve against the observance's own offset rather than the JVM default zone.
+- The resulting `ZoneRules` become **deterministic across JVM default time zones**.
+- A regression test exercises `ZoneRulesBuilder` under a forced non-UTC default zone so this class of bug is caught by CI in future.
+
+## Capabilities
+
+### New Capabilities
+<!-- None. -->
+
+### Modified Capabilities
+- `vtimezone-zonerules`: Add the guarantee that derived `ZoneRules` are independent of the JVM default time zone; historical DST transitions bounded by a UTC `UNTIL` are computed using the observance offset.
+
+## Impact
+
+- Code: `net.fortuna.ical4j.model.ZoneRulesBuilder#buildDSTTransitions`.
+- Behavior: zones with historical (expired) DST defined via `RRULE ... UNTIL=<UTC>` now resolve consistently regardless of host time zone; `Asia/Tokyo` resolves to +09:00 everywhere.
+- Tests: `ZoneRulesBuilderTest` (existing `Asia/Tokyo`/`Asia/Shanghai` rows now pass everywhere) plus a new non-UTC-default-zone regression test.
+- Risk: Low and targeted — change is confined to how the recurrence seed is constructed in one method; `getLatestOnset` already uses the offset-aware approach, so this aligns the two recurrence paths.

--- a/openspec/changes/archive/2026-06-02-fix-zonerules-default-timezone-dependence/specs/vtimezone-zonerules/spec.md
+++ b/openspec/changes/archive/2026-06-02-fix-zonerules-default-timezone-dependence/specs/vtimezone-zonerules/spec.md
@@ -1,0 +1,17 @@
+## ADDED Requirements
+
+### Requirement: ZoneRules derivation is independent of the JVM default time zone
+
+The system SHALL derive identical `java.time.zone.ZoneRules` from a given `VTimeZone` regardless of the JVM default time zone (`java.util.TimeZone.getDefault()` / `TimeZones.getDefault()`). In particular, when building historical DST transitions from an observance whose `RRULE` is bounded by a UTC `UNTIL`, the recurrence set SHALL be computed using the observance's own `TZOFFSETFROM` offset rather than the JVM default zone, so that the `UNTIL` comparison is deterministic.
+
+#### Scenario: Asia/Tokyo resolves to +09:00 in any default zone
+
+- **WHEN** `ZoneRules` are built from the registry `Asia/Tokyo` `VTimeZone` (which encodes expired 1948–1951 DST observances)
+- **THEN** the offset for any present-day date is `+09:00`
+- **AND** the result is the same whether the JVM default zone is `UTC`, `Australia/Sydney`, or any other zone
+
+#### Scenario: Expired historical DST does not leave a zone permanently in daylight time
+
+- **WHEN** an observance defines a DST start via `RRULE ... UNTIL=<UTC instant>` whose final occurrence lies on the `UNTIL` boundary
+- **THEN** the built `ZoneRules` either include both the matching DST start and its closing standard-time transition, or neither
+- **AND** the zone is not left in a daylight (offset-advanced) state after the last historical transition

--- a/openspec/changes/archive/2026-06-02-fix-zonerules-default-timezone-dependence/tasks.md
+++ b/openspec/changes/archive/2026-06-02-fix-zonerules-default-timezone-dependence/tasks.md
@@ -1,0 +1,17 @@
+## 1. Implement the fix
+
+- [x] 1.1 In `ZoneRulesBuilder.buildDSTTransitions`, replace the floating `LocalDateTime` recurrence seed with offset-aware temporals: build the `Period` from `startDate.atOffset(offsetFrom.getOffset())` and `periodEnd.atOffset(offsetFrom.getOffset())`
+- [x] 1.2 Confirm the recurrence-set consumer still derives the correct local onset (`LocalDateTime.from(p.getStart())`) and that `ZoneOffsetTransition.of(...)` arguments are otherwise unchanged
+- [x] 1.3 Add a brief comment explaining the offset-aware seed prevents the JVM-default-zone-dependent `UNTIL` comparison (reference `getLatestOnset` as the precedent)
+
+## 2. Tests
+
+- [x] 2.1 Add a dedicated regression spec (`ZoneRulesTimezoneIndependenceTest`) asserting historical-DST zones (`Asia/Tokyo` +09:00, `Asia/Shanghai` +08:00) resolve to their standard offset in winter and summer. NOTE: an in-test `TimeZone.setDefault` has no effect because `TemporalComparator.INSTANCE` captures the default zone once at class-load — the zone must be set at JVM startup, so a dedicated Gradle test task forces it
+- [x] 2.2 Add a Gradle `timezoneIndependenceTest` task that runs the spec with `-Duser.timezone=Australia/Sydney` and wire it into `check`; exclude the spec from the default `test` task (which would run it under the host zone with no signal on UTC CI)
+- [x] 2.3 Confirm the existing `'test build rules'` rows (including the `Asia/Tokyo` and `Asia/Shanghai` expectations) pass
+
+## 3. Verify
+
+- [x] 3.1 Run `ZoneRulesBuilderTest` under the host (non-UTC) default zone and confirm all rows pass — this is the configuration that previously failed
+- [x] 3.2 Run the full timezone-related suite (`TimeZoneTest`, `CalendarBuilderTimezoneTest`, `VTimezoneTest`, `TimeZoneRegistryTest`, etc.) and confirm no regressions
+- [x] 3.3 Run the full test suite and confirm green

--- a/openspec/specs/vtimezone-zonerules/spec.md
+++ b/openspec/specs/vtimezone-zonerules/spec.md
@@ -2,9 +2,27 @@
 
 ## Purpose
 
-Defines the contract for `net.fortuna.ical4j.model.ZoneRulesBuilder` — deriving a `java.time.zone.ZoneRules` instance from a `net.fortuna.ical4j.model.component.VTimeZone`. Covers how observance `RRULE`s are translated into future `ZoneOffsetTransitionRule`s, including degenerate rules (e.g. non-DST zones emitted by Apple Calendar) that omit a weekday, and which observances are ignored.
+Defines the contract for `net.fortuna.ical4j.model.ZoneRulesBuilder` — deriving a `java.time.zone.ZoneRules` instance from a `net.fortuna.ical4j.model.component.VTimeZone`. Covers how observance `RRULE`s are translated into future `ZoneOffsetTransitionRule`s, including degenerate rules (e.g. non-DST zones emitted by Apple Calendar) that omit a weekday, which observances are ignored, and the guarantee that derivation does not depend on the JVM default time zone.
 
 ## Requirements
+
+### Requirement: ZoneRules derivation is independent of the JVM default time zone
+
+The system SHALL derive identical `java.time.zone.ZoneRules` from a given `VTimeZone` regardless of the JVM default time zone (`java.util.TimeZone.getDefault()` / `TimeZones.getDefault()`). In particular, when building historical DST transitions from an observance whose `RRULE` is bounded by a UTC `UNTIL`, the recurrence set SHALL be computed using the observance's own `TZOFFSETFROM` offset rather than the JVM default zone, so that the `UNTIL` comparison is deterministic.
+
+#### Scenario: Asia/Tokyo resolves to +09:00 in any default zone
+
+- **WHEN** `ZoneRules` are built from the registry `Asia/Tokyo` `VTimeZone` (which encodes expired 1948–1951 DST observances)
+- **THEN** the offset for any present-day date is `+09:00`
+- **AND** the result is the same whether the JVM default zone is `UTC`, `Australia/Sydney`, or any other zone
+
+#### Scenario: Expired historical DST does not leave a zone permanently in daylight time
+
+- **WHEN** an observance defines a DST start via `RRULE ... UNTIL=<UTC instant>` whose final occurrence lies on the `UNTIL` boundary
+- **THEN** the built `ZoneRules` either include both the matching DST start and its closing standard-time transition, or neither
+- **AND** the zone is not left in a daylight (offset-advanced) state after the last historical transition
+
+
 
 ### Requirement: Future transition rules from BYMONTH-only observance RRULEs
 

--- a/src/main/java/net/fortuna/ical4j/model/ZoneRulesBuilder.java
+++ b/src/main/java/net/fortuna/ical4j/model/ZoneRulesBuilder.java
@@ -4,6 +4,7 @@ import net.fortuna.ical4j.model.component.Observance;
 import net.fortuna.ical4j.model.component.Standard;
 import net.fortuna.ical4j.model.component.VTimeZone;
 import net.fortuna.ical4j.model.property.DtStart;
+import net.fortuna.ical4j.model.property.RDate;
 import net.fortuna.ical4j.model.property.RRule;
 import net.fortuna.ical4j.model.property.TzOffsetFrom;
 import net.fortuna.ical4j.model.property.TzOffsetTo;
@@ -12,6 +13,7 @@ import net.fortuna.ical4j.util.CompatibilityHints;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.temporal.Temporal;
 import java.time.zone.ZoneOffsetTransition;
@@ -20,6 +22,7 @@ import java.time.zone.ZoneOffsetTransitionRule.TimeDefinition;
 import java.time.zone.ZoneRules;
 import java.util.*;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static net.fortuna.ical4j.model.Property.TZOFFSETFROM;
 
@@ -102,19 +105,40 @@ public class ZoneRulesBuilder {
                 if (periodEnd.isBefore(startDate)) {
                     periodEnd = startDate.plusYears(5);
                 }
-                var recurrenceSet = observance.calculateRecurrenceSet(new Period<>(startDate, periodEnd));
-                if (recurrenceSet.isEmpty()) {
-                    // A non-recurring observance (no RRULE/RDATE) defines a single transition at its
-                    // DTSTART, but calculateRecurrenceSet omits the zero-duration initial instance that
-                    // lies exactly on the period start boundary. Add it explicitly; otherwise the zone
-                    // collapses to a single fixed offset and DST is never applied (issue #793).
-                    transitions.add(ZoneOffsetTransition.of(startDate,
-                            offsetFrom.get().getOffset(), offsetTo.getOffset()));
-                } else {
-                    recurrenceSet.forEach(p -> transitions.add(ZoneOffsetTransition.of(
-                            LocalDateTime.from(p.getStart()),
-                            offsetFrom.get().getOffset(), offsetTo.getOffset())));
+                final LocalDateTime rangeEnd = periodEnd;
+
+                // Generate onset instances with offset-aware recurrence seeding. The generic
+                // Component.calculateRecurrenceSet anchors recurrence on the floating DTSTART, so when
+                // an RRULE UNTIL is expressed in UTC (as required for VTIMEZONE) the comparison resolves
+                // the floating candidate via TimeZones.getDefault() - making the derived ZoneRules depend
+                // on the JVM default zone (e.g. Asia/Tokyo's expired 1948-1951 DST yields +10:00 east of
+                // UTC). Seeding getDates with an OffsetDateTime at TZOFFSETFROM makes the UNTIL comparison
+                // deterministic, mirroring Observance.getLatestOnset.
+                final ZoneOffset offset = offsetFrom.get().getOffset();
+                final SortedSet<LocalDateTime> onsets = new TreeSet<>();
+                // the initial instance is always a transition onset (also covers non-recurring
+                // observances, whose single DTSTART transition must not be dropped - issue #793).
+                onsets.add(startDate);
+
+                final OffsetDateTime seed = startDate.atOffset(offset);
+                final OffsetDateTime limit = periodEnd.atOffset(offset);
+                final List<RRule<OffsetDateTime>> rrules = observance.getProperties(Property.RRULE);
+                for (RRule<OffsetDateTime> rrule : rrules) {
+                    rrule.getRecur().getDates(seed, seed, limit)
+                            .forEach(d -> onsets.add(d.toLocalDateTime()));
                 }
+                final List<RDate<LocalDateTime>> rdates = observance.getProperties(Property.RDATE);
+                for (RDate<LocalDateTime> rdate : rdates) {
+                    // RDATE may carry either date-time values or periods (VALUE=PERIOD); the period
+                    // start is the transition onset in the latter case.
+                    final Stream<LocalDateTime> rdateOnsets = rdate.getPeriods().isPresent()
+                            ? rdate.getPeriods().get().stream().map(p -> LocalDateTime.from(p.getStart()))
+                            : rdate.getDates().stream();
+                    rdateOnsets.filter(d -> !d.isBefore(startDate) && !d.isAfter(rangeEnd))
+                            .forEach(onsets::add);
+                }
+
+                onsets.forEach(d -> transitions.add(ZoneOffsetTransition.of(d, offset, offsetTo.getOffset())));
             }
         }
         return transitions;

--- a/src/test/groovy/net/fortuna/ical4j/model/ZoneRulesTimezoneIndependenceTest.groovy
+++ b/src/test/groovy/net/fortuna/ical4j/model/ZoneRulesTimezoneIndependenceTest.groovy
@@ -1,0 +1,40 @@
+package net.fortuna.ical4j.model
+
+import spock.lang.Specification
+
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+
+/**
+ * Guards against {@link ZoneRulesBuilder} deriving different {@link java.time.zone.ZoneRules}
+ * depending on the JVM default time zone.
+ *
+ * <p>The bug this guards: historical DST observances bounded by a UTC {@code UNTIL} (e.g.
+ * Asia/Tokyo's expired 1948-1951 DST) were filtered by comparing a floating recurrence candidate
+ * against the UTC {@code UNTIL} via {@code TimeZones.getDefault()}. As a result the zone resolved
+ * to +09:00 when the default zone was UTC (CI) but +10:00 east of UTC (e.g. Australia).
+ *
+ * <p>{@code TemporalComparator.INSTANCE} captures the default zone once at class-load, so this
+ * behaviour can only be exercised by starting the JVM in a non-UTC zone. The Gradle
+ * {@code timezoneIndependenceTest} task runs this spec with {@code -Duser.timezone=Australia/Sydney}.
+ */
+class ZoneRulesTimezoneIndependenceTest extends Specification {
+
+    def 'historical-DST zones resolve to their standard offset regardless of JVM default zone: #tzId'() {
+        given: 'a registry timezone whose DST is entirely historical (expired UNTIL)'
+        def registry = TimeZoneRegistryFactory.instance.createRegistry()
+        def vtz = registry.getTimeZone(tzId).getVTimeZone()
+
+        when: 'zone rules are built and queried for present-day offsets'
+        def zonerules = new ZoneRulesBuilder().vTimeZone(vtz).build()
+
+        then: 'the offset is the standard offset in both winter and summer, independent of default zone'
+        zonerules.getOffset(LocalDateTime.of(2026, 1, 1, 0, 0)) == expectedOffset
+        zonerules.getOffset(LocalDateTime.of(2026, 6, 29, 0, 0)) == expectedOffset
+
+        where:
+        tzId             | expectedOffset
+        'Asia/Tokyo'     | ZoneOffset.ofHours(9)
+        'Asia/Shanghai'  | ZoneOffset.ofHours(8)
+    }
+}


### PR DESCRIPTION
## Why

`ZoneRulesBuilder` produced **different `ZoneRules` depending on the JVM default time zone**. `Asia/Tokyo` resolved to **+09:00** when the default zone was UTC (GitHub Actions CI) but **+10:00** east of UTC (e.g. `Australia/*`) — so `ZoneRulesBuilderTest`'s `Asia/Tokyo` rows passed on CI and failed locally, and consumers in non-UTC zones got wrong offsets.

### Root cause

`buildDSTTransitions` computed an observance's recurrence set via `Component.calculateRecurrenceSet`, which anchors recurrence on the **floating** `DTSTART`. When an RRULE `UNTIL` is expressed in UTC (as required for VTIMEZONE), `Recur` compared the floating candidate against `UNTIL` through `TemporalComparator`, which resolves floating temporals using `TimeZones.getDefault()`.

For `Asia/Tokyo`'s expired 1948–1951 DST, the final DAYLIGHT candidate `1951-05-06T00:00`:
- **UTC** → `1951-05-06T00:00Z` > UNTIL → excluded.
- **+10** → `1951-05-05T14:00Z` < UNTIL → **included**, but its closing STANDARD transition was dropped → the zone was stuck at +10:00 forever.

## What changed

- `ZoneRulesBuilder.buildDSTTransitions` now generates onsets with **offset-aware recurrence seeding** (an `OffsetDateTime` at `TZOFFSETFROM`), mirroring `Observance.getLatestOnset`. The `UNTIL` comparison is then `OffsetDateTime` vs `Instant` — deterministic, no default-zone dependence. RDATE periods and the initial `DTSTART` instance (issue #793) are handled explicitly.
- Result: both UTC and non-UTC default zones now produce **identical** transitions, including the closing `1951-09-09 → +09:00` — so Tokyo resolves to +09:00 everywhere.

## Tests

`TemporalComparator.INSTANCE` captures the default zone once at class-load, so an in-test `setDefault()` has no effect — the zone must be set at JVM startup. Therefore:
- New `ZoneRulesTimezoneIndependenceTest` asserts `Asia/Tokyo` (+09:00) and `Asia/Shanghai` (+08:00) resolve to their standard offset in winter and summer.
- New Gradle `timezoneIndependenceTest` task runs it under `-Duser.timezone=Australia/Sydney`, wired into `check`. Verified it **fails without the fix** and passes with it — so CI now guards this class of bug despite running in UTC.

Full suite (2787 tests) + the new guard are green locally (under an Australian default zone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)