### PR TITLE
ci: bump deprecated actions in scorecards workflow

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -27,7 +27,7 @@ jobs:
           persist-credentials: false
 
       - name: OSSF Scorecard action
-        uses: ossf/scorecard-action@v2.1.3
+        uses: ossf/scorecard-action@v2.4.0
         with:
           results_file: results.sarif
           results_format: sarif
@@ -42,7 +42,7 @@ jobs:
 
       # Upload the results as artifacts (optional).
       - name: "Upload artifact"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: SARIF file
           path: results.sarif
@@ -50,6 +50,6 @@ jobs:
 
       # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Problem

The **Scorecards supply-chain security** workflow has been failing in CI — on both the scheduled run (e.g. 2026-06-03) and the latest push to `develop`. The job dies in ~6 seconds during *Set up job*, before any step executes:

> This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. ([deprecation notice](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/))

GitHub validates all referenced actions up front and now hard-fails workflows that pin `actions/upload-artifact@v3`, so the whole job fails at setup. This is pre-existing and unrelated to any recent code change.

## Fix

Bump the deprecated action versions in `.github/workflows/scorecards.yml`:

| Action | Before | After |
|---|---|---|
| `actions/upload-artifact` | `v3` | `v4` |
| `github/codeql-action/upload-sarif` | `v2` | `v3` |
| `ossf/scorecard-action` | `v2.1.3` | `v2.4.0` |

`actions/upload-artifact@v3` is the direct cause. `github/codeql-action@v2` is also deprecated (would fail similarly once setup proceeds), and `ossf/scorecard-action` is bumped to a current release that is compatible with `upload-artifact@v4`. These align the file with the current OSSF Scorecard starter workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)