### PR TITLE
ci: use built-in GITHUB_TOKEN for scorecards instead of expired PAT

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -17,6 +17,8 @@ jobs:
     permissions:
       # Needed to upload the results to code-scanning dashboard.
       security-events: write
+      # Needed to publish results and get a badge (via OIDC).
+      id-token: write
       actions: read
       contents: read
 
@@ -31,9 +33,9 @@ jobs:
         with:
           results_file: results.sarif
           results_format: sarif
-          # Read-only PAT token. To create it,
-          # follow the steps in https://github.com/ossf/scorecard-action#pat-token-creation.
-          repo_token: ${{ secrets.SCORECARD_READ_TOKEN }}
+          # Use the built-in workflow token. A PAT is only required for the Branch-Protection
+          # check on public repos; the default GITHUB_TOKEN covers the remaining checks.
+          repo_token: ${{ github.token }}
           # Publish the results to enable scorecard badges. For more details, see
           # https://github.com/ossf/scorecard-action#publishing-results.
           # For private repositories, `publish_results` will automatically be set to `false`,


### PR DESCRIPTION
## Problem

After #891 fixed the deprecated-action hard-fail, the Scorecards workflow ran far enough to expose a second, pre-existing failure:

> Error: scorecard.Run: repo unreachable: GET https://api.github.com/repos/ical4j/ical4j: **401 Bad credentials**

The `repo_token: ${{ secrets.SCORECARD_READ_TOKEN }}` PAT secret is missing/expired, so the action can't authenticate. This was masked earlier because the job died at setup before reaching the Scorecard step.

## Fix

Use the built-in workflow token instead of the PAT:

- `repo_token` → `${{ github.token }}` — the default `GITHUB_TOKEN` can read this public repo and covers all checks except **Branch-Protection** (the only check that needs a classic PAT). No secret to maintain or rotate.
- Add `id-token: write` permission so `publish_results: true` can still publish results / power the badge via OIDC.

### Trade-off

The **Branch-Protection** check will return limited results without a PAT. If full Branch-Protection scoring is wanted later, set a classic PAT (repo scope) as `SCORECARD_READ_TOKEN` and point `repo_token` back at it.

### Verification note

The scorecards workflow only runs on `push`/`schedule`/`branch_protection_rule` to `develop`, **not** on PRs — so it won't execute against this PR. It will run on the merge to `develop`; I'll confirm it goes green there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)