### PR TITLE
Throw exception when `ZoneIdPool` is exhausted

### DIFF
--- a/src/main/java/net/fortuna/ical4j/model/ZoneRulesProviderImpl.java
+++ b/src/main/java/net/fortuna/ical4j/model/ZoneRulesProviderImpl.java
@@ -90,11 +90,13 @@ public class ZoneRulesProviderImpl extends ZoneRulesProvider {
         public synchronized String allocate(TimeZoneRegistry registry) {
             cleanup();
             String zoneId = availableZoneIds.poll();
-            if (zoneId != null) {
-                allocatedZoneIds.put(zoneId, new WeakReference<>(registry));
-                if (LOG.isTraceEnabled()) {
-                    LOG.trace("Allocated zone ID: {} ({} remaining)", zoneId, availableZoneIds());
-                }
+            if (zoneId == null) {
+                throw new RuntimeException("Ran out of available zone IDs");
+            }
+
+            allocatedZoneIds.put(zoneId, new WeakReference<>(registry));
+            if (LOG.isTraceEnabled()) {
+                LOG.trace("Allocated zone ID: {} ({} remaining)", zoneId, availableZoneIds());
             }
             refresh.set(true);
             return zoneId;

--- a/src/test/java/net/fortuna/ical4j/model/ZoneIdPoolTest.java
+++ b/src/test/java/net/fortuna/ical4j/model/ZoneIdPoolTest.java
@@ -1,0 +1,33 @@
+package net.fortuna.ical4j.model;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+class ZoneIdPoolTest {
+
+    @Test
+    void poolRunsOutOfZoneIds() {
+        var zoneRulesProvider = new ZoneRulesProviderImpl();
+        var zonePoolId = zoneRulesProvider.getZoneIdPool();
+        var timeZoneRegistry = new TimeZoneRegistryImpl();
+
+        // Allocate all available zone IDs from ZoneIdPool
+        @SuppressWarnings("MismatchedQueryAndUpdateOfCollection")
+        var zoneIds = new ArrayList<String>(zonePoolId.availableZoneIds());
+        while (zonePoolId.availableZoneIds() > 0) {
+            zoneIds.add(zonePoolId.allocate(timeZoneRegistry));
+        }
+
+        try {
+            zonePoolId.allocate(timeZoneRegistry);
+            fail("Expected exception");
+        } catch (RuntimeException e) {
+            assertEquals(RuntimeException.class, e.getClass());
+            assertEquals("Ran out of available zone IDs", e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
Instead of the `NullPointerException` we get the following exception/stacktrace:

```text
net.fortuna.ical4j.data.ParserException: Error at line 22:Ran out of available zone IDs
	at net.fortuna.ical4j.data.CalendarParserImpl.parse(CalendarParserImpl.java:167)
	at net.fortuna.ical4j.data.CalendarBuilder.build(CalendarBuilder.java:197)
	at net.fortuna.ical4j.data.CalendarBuilder.build(CalendarBuilder.java:185)
	[…]
Caused by: java.lang.RuntimeException: Ran out of available zone IDs
	at net.fortuna.ical4j.model.ZoneRulesProviderImpl$ZoneIdPool.allocate(ZoneRulesProviderImpl.java:94)
	at net.fortuna.ical4j.model.TimeZoneRegistryImpl.register(TimeZoneRegistryImpl.java:166)
	at net.fortuna.ical4j.model.TimeZoneRegistryImpl.register(TimeZoneRegistryImpl.java:143)
	at net.fortuna.ical4j.data.DefaultContentHandler.endComponent(DefaultContentHandler.java:129)
	at net.fortuna.ical4j.data.CalendarParserImpl$ComponentParser.parse(CalendarParserImpl.java:461)
	at net.fortuna.ical4j.data.CalendarParserImpl$PropertyListParser.parse(CalendarParserImpl.java:217)
	at net.fortuna.ical4j.data.CalendarParserImpl.parseCalendar(CalendarParserImpl.java:126)
	at net.fortuna.ical4j.data.CalendarParserImpl.parseCalendarList(CalendarParserImpl.java:188)
	[…]
```

Fixes #894