### PR TITLE
fix: map BYDAY ordinals to java.time day-of-month indicators in ZoneRulesBuilder

### DIFF
--- a/src/main/java/net/fortuna/ical4j/model/ZoneRulesBuilder.java
+++ b/src/main/java/net/fortuna/ical4j/model/ZoneRulesBuilder.java
@@ -194,10 +194,12 @@ public class ZoneRulesBuilder {
                 int dayOfMonth;
                 java.time.DayOfWeek dayOfWeek;
                 if (!recur.getDayList().isEmpty()) {
-                    dayOfMonth = recur.getDayList().get(0).getOffset();
-                    if (dayOfMonth == 0) {
+                    int ordinal = recur.getDayList().get(0).getOffset();
+                    if (ordinal == 0) {
                         dayOfMonth = recur.getMonthDayList().isEmpty()
                                 ? startDate.getDate().getDayOfMonth() : recur.getMonthDayList().get(0);
+                    } else {
+                        dayOfMonth = dayOfMonthIndicator(ordinal);
                     }
                     dayOfWeek = WeekDay.getDayOfWeek(recur.getDayList().get(0));
                 } else if (!recur.getMonthDayList().isEmpty()) {
@@ -218,6 +220,32 @@ public class ZoneRulesBuilder {
         //  Note the order of the list is significant!
         transitionRules.sort(Comparator.comparing(ZoneOffsetTransitionRule::getMonth));
         return transitionRules;
+    }
+
+    /**
+     * Translates an RFC5545 BYDAY ordinal (the {@code 2} in {@code 2SU}) to the day-of-month
+     * indicator expected by {@link ZoneOffsetTransitionRule#of}.
+     * <p>
+     * When that factory is given a non-null day-of-week the indicator is not an ordinal. A positive
+     * value selects the first matching weekday on or after that day-of-month; a negative value is
+     * counted back from the end of the month, where {@code -1} is the last day, and selects the last
+     * matching weekday on or before it. Passing the ordinal through unchanged therefore reads
+     * {@code 2SU} as "the first Sunday on or after the 2nd", which can be a week early.
+     * <p>
+     * The nth weekday from the start of a month always falls within {@code [(n-1)*7+1, (n-1)*7+7]},
+     * so anchoring at {@code (n-1)*7+1} selects exactly the nth. By symmetry the nth weekday from the
+     * end always falls within the seven days ending at {@code -((n-1)*7+1)}, so anchoring there
+     * selects exactly the nth from the end. {@code -1} maps to itself, which is why zones using
+     * {@code -1SU} were unaffected.
+     *
+     * @param ordinal a non-zero BYDAY ordinal
+     * @return the equivalent day-of-month indicator
+     */
+    private static int dayOfMonthIndicator(int ordinal) {
+        int indicator = ordinal > 0 ? (ordinal - 1) * 7 + 1 : (ordinal + 1) * 7 - 1;
+        // ordinals further from the end of the month than the fourth week (e.g. -5SU) fall outside
+        // the -28..31 range ZoneOffsetTransitionRule accepts; clamp rather than throw.
+        return Math.max(-28, Math.min(31, indicator));
     }
 
     public ZoneRules build() throws ConstraintViolationException {

--- a/src/test/groovy/net/fortuna/ical4j/model/ZoneRulesBuilderTest.groovy
+++ b/src/test/groovy/net/fortuna/ical4j/model/ZoneRulesBuilderTest.groovy
@@ -224,4 +224,125 @@ END:VCALENDAR'''
         then:
         noExceptionThrown()
     }
+
+    @Unroll
+    def 'BYDAY ordinal transition rule matches the JDK tzdb: #tzId #month #year'() {
+        given: 'zone rules derived from the bundled VTIMEZONE'
+        def zonerules = new ZoneRulesBuilder()
+                .vTimeZone(timeZoneRegistry.getTimeZone(tzId).getVTimeZone()).build()
+
+        and: 'the transition the JDK tzdb reports for the same zone, month and year'
+        def zoneId = ZoneId.of(tzId)
+        def searchFrom = LocalDate.of(year, month, 1).atStartOfDay(zoneId).toInstant()
+        def expected = zoneId.rules.nextTransition(searchFrom).dateTimeBefore.toLocalDate()
+
+        expect: 'a rule exists for that month'
+        def rule = zonerules.transitionRules.find { it.month == month }
+        rule != null
+
+        and: 'projecting it onto the year yields the same date as the JDK'
+        rule.createTransition(year).dateTimeBefore.toLocalDate() == expected
+
+        where:
+        tzId                  | month              | year
+        // BYDAY=2SU - a positive ordinal greater than one. See issue #902: the ordinal was
+        // passed to ZoneOffsetTransitionRule as a day-of-month, so "second Sunday" was read as
+        // "first Sunday on or after the 2nd" and DST started up to a week early. The result was
+        // only correct in years where 1 March happens to be a Sunday, such as 2026.
+        'America/New_York'    | java.time.Month.MARCH        | 2025
+        'America/New_York'    | java.time.Month.MARCH        | 2026
+        'America/New_York'    | java.time.Month.MARCH        | 2027
+        'America/Chicago'     | java.time.Month.MARCH        | 2025
+        'America/Chicago'     | java.time.Month.MARCH        | 2027
+        'America/Los_Angeles' | java.time.Month.MARCH        | 2028
+        // BYDAY=1SU - a positive ordinal of one, which mapped correctly before the fix too
+        'America/New_York'    | java.time.Month.NOVEMBER     | 2025
+        'America/New_York'    | java.time.Month.NOVEMBER     | 2026
+        // BYDAY=-1SU - a negative ordinal, counted back from the end of the month
+        'Europe/Paris'        | java.time.Month.MARCH        | 2025
+        'Europe/Paris'        | java.time.Month.MARCH        | 2026
+        'Europe/Paris'        | java.time.Month.OCTOBER      | 2025
+        'Europe/Paris'        | java.time.Month.OCTOBER      | 2027
+        'Europe/London'       | java.time.Month.OCTOBER      | 2026
+    }
+
+    @Unroll
+    def 'BYDAY ordinal #byDay maps to day-of-month indicator #expectedIndicator'() {
+        given: 'a VTIMEZONE whose DAYLIGHT observance uses the given BYDAY ordinal'
+        def cal = """BEGIN:VCALENDAR
+BEGIN:VTIMEZONE
+TZID:Test/Ordinal
+BEGIN:DAYLIGHT
+DTSTART:20000312T020000
+RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=$byDay
+TZOFFSETFROM:-0500
+TZOFFSETTO:-0400
+END:DAYLIGHT
+BEGIN:STANDARD
+DTSTART:20001105T020000
+RRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU
+TZOFFSETFROM:-0400
+TZOFFSETTO:-0500
+END:STANDARD
+END:VTIMEZONE
+END:VCALENDAR"""
+
+        when: 'zone rules are built'
+        def calendar = new CalendarBuilder().build(new StringReader(cal))
+        def zonerules = new ZoneRulesBuilder().vTimeZone(calendar.getComponent('VTIMEZONE').get()).build()
+        def march = zonerules.transitionRules.find { it.month == java.time.Month.MARCH }
+
+        then: 'the RFC5545 ordinal is translated to the java.time indicator, keeping the weekday'
+        march.dayOfMonthIndicator == expectedIndicator
+        march.dayOfWeek == DayOfWeek.SUNDAY
+
+        where:
+        byDay   | expectedIndicator
+        '1SU'   | 1
+        '2SU'   | 8
+        '3SU'   | 15
+        '4SU'   | 22
+        '-1SU'  | -1
+        '-2SU'  | -8
+        '-3SU'  | -15
+        '-4SU'  | -22
+        // beyond the fourth week from the end the indicator would leave the -28..31 range that
+        // ZoneOffsetTransitionRule accepts, so it is clamped instead of throwing
+        '-5SU'  | -28
+    }
+
+    def 'BYDAY without an ordinal falls back to BYMONTHDAY or DTSTART'() {
+        given: 'a VTIMEZONE using a plain weekday (no ordinal) in BYDAY'
+        def cal = """BEGIN:VCALENDAR
+BEGIN:VTIMEZONE
+TZID:Test/NoOrdinal
+BEGIN:DAYLIGHT
+DTSTART:20000312T020000
+RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=SU$byMonthDay
+TZOFFSETFROM:-0500
+TZOFFSETTO:-0400
+END:DAYLIGHT
+BEGIN:STANDARD
+DTSTART:20001105T020000
+RRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU
+TZOFFSETFROM:-0400
+TZOFFSETTO:-0500
+END:STANDARD
+END:VTIMEZONE
+END:VCALENDAR"""
+
+        when: 'zone rules are built'
+        def calendar = new CalendarBuilder().build(new StringReader(cal))
+        def zonerules = new ZoneRulesBuilder().vTimeZone(calendar.getComponent('VTIMEZONE').get()).build()
+        def march = zonerules.transitionRules.find { it.month == java.time.Month.MARCH }
+
+        then: 'the ordinal-free weekday is not run through the ordinal mapping'
+        march.dayOfMonthIndicator == expectedIndicator
+        march.dayOfWeek == DayOfWeek.SUNDAY
+
+        where:
+        byMonthDay          | expectedIndicator
+        ''                  | 12      // no BYMONTHDAY - falls back to the DTSTART day
+        ';BYMONTHDAY=8,9,10,11,12,13,14' | 8
+    }
 }


### PR DESCRIPTION
Fixes #902.

## The bug

VTIMEZONE DAYLIGHT/STANDARD observances express their transition day with BYDAY, which carries an ordinal: `America/New_York` uses `BYDAY=2SU`, `Europe/Paris` uses `BYDAY=-1SU`. `buildTransitionRules` passed `WeekDay.getOffset()` — the raw ordinal — straight into `ZoneOffsetTransitionRule.of` as the `dayOfMonthIndicator` argument.

`java.time` does not read that argument as an ordinal. With a non-null `dayOfWeek` the javadoc defines it as "the day of the month-day of the cutover week, positive if the week is that day or later, negative if the week is that day or earlier, counting from the last day of the month, from -28 to 31 excluding 0". So `BYDAY=2SU` was evaluated as "the first Sunday on or after the 2nd" — which is the *first* Sunday whenever 1 March is not itself a Sunday. `-1SU` maps to itself, which is why Western European zones looked correct and US zones did not.

## Scope — a correction to the issue's numbers

`buildDSTTransitions` expands concrete transitions only as far as `LocalDateTime.now()`, and those correct entries mask the rules for past dates. So the year-by-year examples in the issue do not reproduce through `ZoneRules` today: 2025 and 2026 are still covered by the concrete list. What the rules actually govern is everything from the next transition onward, and there every affected zone lands a week early:

| year | derived | tzdb |
|---|---|---|
| 2027 | 2027-03-07 | 2027-03-14 |
| 2028 | 2028-03-05 | 2028-03-12 |
| 2040 | 2040-03-04 | 2040-03-11 |

The issue's *rule-level* diagnosis is exactly right, including the observation that it is correct only when 1 March is a Sunday — 2026 passes before this fix and 2025/2027 do not. I mention the difference only so the impact statement is accurate.

The bundled zoneinfo contains 157 `2SU`, 98 `3SU`, 29 `4SU` and 33 `3MO` rules, so this covers the US and Canadian zones plus `Europe/Istanbul`, `Europe/Minsk` and several Russian zones.

## The fix

A private helper translates the ordinal to the indicator `java.time` expects. The nth weekday from the start of a month always falls within `[(n-1)*7+1, (n-1)*7+7]`, so anchoring at `(n-1)*7+1` selects exactly the nth: 1, 8, 15, 22. By symmetry the nth weekday from the end falls within the seven days ending at `-((n-1)*7+1)`, giving -1, -8, -15, -22.

Both branches were checked against `ZoneOffsetTransitionRule.of` over 1900-2100, every month, every weekday, ordinals ±1..4 — 135,072 cases, no mismatches.

**The negative branch does need mapping too.** This is worth stating because the patch sketched in the issue leaves negative ordinals unchanged, and that is correct only at `-1`. Verified against the JDK for October 2025:

```
-1SU want=2025-10-26 | ordinal as-is (ind=-1)=2025-10-26 OK  | mapped (ind=-1)=2025-10-26 OK
-2SU want=2025-10-19 | ordinal as-is (ind=-2)=2025-10-26 WRONG | mapped (ind=-8)=2025-10-19 OK
-3SU want=2025-10-12 | ordinal as-is (ind=-3)=2025-10-26 WRONG | mapped (ind=-15)=2025-10-12 OK
-4SU want=2025-10-05 | ordinal as-is (ind=-4)=2025-10-26 WRONG | mapped (ind=-22)=2025-10-05 OK
```

Every negative ordinal past `-1` resolves to the last matching weekday. Over the same ±1..5 sweep the unmapped form fails 8,347 cases.

Two edge cases handled deliberately:

- **BYDAY without an ordinal** (offset 0, 352 occurrences in the bundled data) still falls back to BYMONTHDAY or the DTSTART day. The zero check now runs *before* the mapping, since applying the formula to 0 would give -6. There is a test for it.
- **Ordinals past the fourth week from the end** (`-5SU`) would produce -29, outside the -28..31 range `of()` accepts, so the helper clamps rather than introducing a throw where there previously was none. No bundled zone uses an ordinal beyond ±4.

## Tests

`ZoneRulesBuilderTest` gains three data-driven features:

- the rules derived from the bundled VTIMEZONE must agree with `ZoneId.of(...).getRules()` on the transition date, across `America/New_York`, `America/Chicago`, `America/Los_Angeles`, `Europe/Paris` and `Europe/London`, in a year where 1 March is a Sunday (2026) and years where it is not (2025, 2027, 2028)
- the ordinal-to-indicator mapping itself, `1SU`..`4SU` and `-1SU`..`-5SU`
- the ordinal-free BYDAY fallback, with and without BYMONTHDAY

Against unmodified `develop`, 11 of them fail — for example `America/New_York` 2025 producing `2025-03-02` where the JDK has `2025-03-09`, and `2SU` producing indicator 2 rather than 8. `America/New_York` 2026 passes before the fix, which is the coincidence the issue describes, and `Europe/Paris`/`Europe/London` pass throughout.

Full suite on temurin 17: 2791 tests before, 2815 after, with the same single pre-existing failure in `TimeZoneLoaderTest` in both runs (Testcontainers cannot reach a Docker daemon in my environment).

One note in case it saves someone time later: this test class is in `net.fortuna.ical4j.model`, where `Month` shadows `java.time.Month`. A `where:` block using the bare name made Spock silently run zero iterations rather than fail, so the tests are fully qualified as `java.time.Month.*`, matching the existing cases in that file.

## Not addressed

This does not fix #903, which the same reporter filed against the same method. That is a separate defect in the expired-RRULE guard, and `America/Costa_Rica` and `America/Santo_Domingo` still disagree with the JDK with this patch applied. I verified that independently rather than assuming one fix would close both.

I did not add an `openspec/` entry, following the three most recent outside-contributor PRs (#895, #896, #882), which touch only `src/main` and `src/test`. Happy to add one if you would prefer it. `./gradlew checkstyleMain` is not a registered task in this build, so I ran `test` rather than the full `check`.

Credit to @balaboukokota for the report and the diagnosis.

Disclosure: I use AI assistance in my work, and I review and verify everything before it goes out.
